### PR TITLE
Optimize calculation and stabilize PlayerCoordsAPI synchronization

### DIFF
--- a/app/api/places/[id]/route.ts
+++ b/app/api/places/[id]/route.ts
@@ -16,6 +16,7 @@ import { setMapEntrySpace } from '@/lib/map-entry/space-association';
 import { prepareMapEntryUpdate } from '@/lib/map-entry/creation';
 import { updateMapEntryManagement } from '@/lib/map-entry/management-update';
 import { MinecraftProfileError } from '@/lib/minecraft/profiles';
+import { invalidateRouteData } from '../../route/service/route-data';
 
 
 import { UpdatePlaceSchema } from '../../utils/schemas';
@@ -119,6 +120,7 @@ export async function PUT(request: NextRequest, context: any) {
       }
       return updatedPlace;
     });
+    invalidateRouteData();
 
     return NextResponse.json(
       {
@@ -178,6 +180,7 @@ export async function DELETE(request: NextRequest, context: any) {
     await prisma.mapEntry.delete({
       where: { id: place.mapEntryId },
     });
+    invalidateRouteData();
 
     return NextResponse.json({ message: 'Lieu supprimé avec succès.' }, { status: 200 });
   } catch (error: unknown) {

--- a/app/api/places/route.ts
+++ b/app/api/places/route.ts
@@ -13,6 +13,7 @@ import { createMapEntry, MapEntryError } from '@/lib/map-entry/service';
 import { prepareMapEntryCreation } from '@/lib/map-entry/creation';
 import { validateSpaceAssociation } from '@/lib/map-entry/space-association';
 import { MinecraftProfileError } from '@/lib/minecraft/profiles';
+import { invalidateRouteData } from '../route/service/route-data';
 
 export async function GET() {
   try {
@@ -85,6 +86,7 @@ export async function POST(request: NextRequest) {
         },
       });
     });
+    invalidateRouteData();
 
     return NextResponse.json(
       {

--- a/app/api/portals/[id]/route.ts
+++ b/app/api/portals/[id]/route.ts
@@ -16,6 +16,7 @@ import { indexLinkedPortalPairs } from '@/lib/portal/linked-portals';
 import { prepareMapEntryUpdate } from '@/lib/map-entry/creation';
 import { updateMapEntryManagement } from '@/lib/map-entry/management-update';
 import { MinecraftProfileError } from '@/lib/minecraft/profiles';
+import { invalidateRouteData } from '../../route/service/route-data';
 
 import { UpdatePortalSchema } from '../../utils/schemas';
 
@@ -103,6 +104,7 @@ export async function PUT(request: NextRequest, context: any) {
         }
         return updatedPortal;
       });
+      invalidateRouteData();
 
       return NextResponse.json(
         {
@@ -174,6 +176,7 @@ export async function PUT(request: NextRequest, context: any) {
       }
       return { overworldPortal, netherPortal };
     });
+    invalidateRouteData();
 
     return NextResponse.json(
       {
@@ -252,6 +255,7 @@ export async function DELETE(request: NextRequest, context: any) {
           },
         },
       });
+      invalidateRouteData();
 
       return NextResponse.json({ message: 'Portails liés supprimés avec succès.' }, { status: 200 });
 
@@ -291,6 +295,7 @@ export async function DELETE(request: NextRequest, context: any) {
       } else {
         await prisma.portal.delete({ where: { uid: portal.uid } });
       }
+      invalidateRouteData();
 
       return NextResponse.json({ message: 'Portail supprimé avec succès.' }, { status: 200 });
     }

--- a/app/api/portals/route.ts
+++ b/app/api/portals/route.ts
@@ -18,6 +18,7 @@ import {
   indexLinkedPortalPairs,
   mergeLinkedPortalPair,
 } from '@/lib/portal/linked-portals';
+import { invalidateRouteData } from '../route/service/route-data';
 
 const QuerySchema = z.object({
   'merge-nether-portals': z.coerce.boolean().optional().default(false),
@@ -102,6 +103,7 @@ export async function POST(request: NextRequest) {
           },
         });
       });
+      invalidateRouteData();
 
       return NextResponse.json(
         {
@@ -161,6 +163,7 @@ export async function POST(request: NextRequest) {
 
       return { overworldPortal, netherPortal };
     });
+    invalidateRouteData();
 
     return NextResponse.json(
       {

--- a/app/api/route/route-types.ts
+++ b/app/api/route/route-types.ts
@@ -31,3 +31,30 @@ export interface RoutePoint {
   id?: string;
   address?: string;
 }
+
+export interface RouteEntity {
+  id: string;
+  name: string;
+  world: string;
+  coordinates: {
+    x: number;
+    y: number;
+    z: number;
+  };
+  address?: string | null;
+}
+
+export interface RoutePortal extends RouteEntity {
+  slug: string;
+  mapEntryId: string;
+  address: string;
+}
+
+export interface RoutePortalWithDistance extends RoutePortal {
+  distance: number;
+}
+
+export interface RouteDataSet {
+  places: RouteEntity[];
+  portals: RoutePortal[];
+}

--- a/app/api/route/route-utils.ts
+++ b/app/api/route/route-utils.ts
@@ -1,56 +1,68 @@
-import { 
-  Portal, 
+import {
   calculateEuclideanDistance,
-  convertOverworldToNether, 
+  convertOverworldToNether,
   resolveNetherAddressForWorld
 } from '../utils/shared';
-import { RoutePoint } from './route-types';
+import type {
+  RouteEntity,
+  RoutePoint,
+  RoutePortal,
+  RoutePortalWithDistance,
+} from './route-types';
 import { NextResponse } from 'next/server';
-import { Place } from '../utils/shared';
 
-export async function callNearestPortals(x: number, y: number, z: number, world: string, allPortals: Portal[], maxDistance?: number): Promise<(Portal & {distance: number})[]> {
-  const worldPortals = allPortals.filter(portal => portal.world === world);
-  
-  const portalsWithDistance = worldPortals
-    .map(portal => ({
-      ...portal,
-      distance: calculateEuclideanDistance(
-        x, y, z,
-        portal.coordinates.x, portal.coordinates.y, portal.coordinates.z
-      )
-    }))
-    .sort((a, b) => a.distance - b.distance);
-  
-  return maxDistance 
-    ? portalsWithDistance.filter(portal => portal.distance <= maxDistance)
-    : portalsWithDistance;
+export function callNearestPortal(
+  x: number,
+  y: number,
+  z: number,
+  world: string,
+  allPortals: RoutePortal[],
+  maxDistance?: number,
+): RoutePortalWithDistance | null {
+  let nearest: RoutePortalWithDistance | null = null;
+
+  allPortals.forEach((portal) => {
+    if (portal.world !== world) return;
+    const distance = calculateEuclideanDistance(
+      x, y, z,
+      portal.coordinates.x, portal.coordinates.y, portal.coordinates.z,
+    );
+    if (maxDistance !== undefined && distance > maxDistance) return;
+    if (!nearest || distance < nearest.distance) nearest = { ...portal, distance };
+  });
+
+  return nearest;
 }
 
-export async function callLinkedPortal(x: number, y: number, z: number, fromWorld: string, allPortals: Portal[]): Promise<(Portal & {distance: number}) | null> {
+export function callLinkedPortal<T extends RoutePortal>(
+  x: number,
+  y: number,
+  z: number,
+  fromWorld: string,
+  allPortals: T[],
+): (T & { distance: number }) | null {
   const targetWorld = fromWorld === 'overworld' ? 'nether' : 'overworld';
   const searchCoords = fromWorld === 'overworld' 
     ? convertOverworldToNether(x, z)
     : { x: x * 8, z: z * 8 };
   
   const searchRadius = targetWorld === 'overworld' ? 128 : 16;
-  const targetWorldPortals = allPortals.filter(portal => portal.world === targetWorld);
-  
-  const candidatePortals = targetWorldPortals
-    .filter(portal => {
-      const deltaX = Math.abs(portal.coordinates.x - searchCoords.x);
-      const deltaZ = Math.abs(portal.coordinates.z - searchCoords.z);
-      return deltaX <= searchRadius && deltaZ <= searchRadius;
-    })
-    .map(portal => ({
-      ...portal,
-      distance: calculateEuclideanDistance(
-        searchCoords.x, y, searchCoords.z,
-        portal.coordinates.x, portal.coordinates.y, portal.coordinates.z
-      )
-    }))
-    .sort((a, b) => a.distance - b.distance);
-  
-  return candidatePortals.length > 0 ? candidatePortals[0] : null;
+  let nearest: (T & { distance: number }) | null = null;
+
+  allPortals.forEach((portal) => {
+    if (portal.world !== targetWorld) return;
+    const deltaX = Math.abs(portal.coordinates.x - searchCoords.x);
+    const deltaZ = Math.abs(portal.coordinates.z - searchCoords.z);
+    if (deltaX > searchRadius || deltaZ > searchRadius) return;
+
+    const distance = calculateEuclideanDistance(
+      searchCoords.x, y, searchCoords.z,
+      portal.coordinates.x, portal.coordinates.y, portal.coordinates.z,
+    );
+    if (!nearest || distance < nearest.distance) nearest = { ...portal, distance };
+  });
+
+  return nearest;
 }
 
 export async function resolveRoutePoint(
@@ -60,12 +72,12 @@ export async function resolveRoutePoint(
   y: number | undefined,
   z: number | undefined,
   world: string | undefined | null,
-  places: Place[],
-  portals: Portal[],
+  places: RouteEntity[],
+  portals: RoutePortal[],
   pointType: 'from' | 'to'
 ): Promise<RoutePoint | NextResponse> {
   if (isPlace) {
-    let foundPlace: Place | Portal | undefined = places.find(p => p.id === placeId);
+    let foundPlace: RouteEntity | undefined = places.find(p => p.id === placeId);
     if (!foundPlace) {
       foundPlace = portals.find(p => p.id === placeId);
     }

--- a/app/api/route/route.ts
+++ b/app/api/route/route.ts
@@ -1,10 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
-import {
-  loadPlaces,
-  loadPortals,
-} from '../utils/shared';
 import { QuerySchema } from './route-types';
 import { RouteService } from './service/route-service';
+import { loadRouteData } from './service/route-data';
 import { handleError, parseQueryParams } from '../utils/api-utils';
 import { resolveRoutePoint } from './route-utils';
 
@@ -32,9 +29,7 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    // Load places and portals if needed
-    const places = await loadPlaces();
-    const portals = await loadPortals();
+    const { places, portals } = await loadRouteData();
 
     // Resolve from point
     const fromPointResult = await resolveRoutePoint(

--- a/app/api/route/service/helpers.ts
+++ b/app/api/route/service/helpers.ts
@@ -1,21 +1,20 @@
 import {
   convertOverworldToNether,
   resolveNetherAddressForWorld,
-  type Portal,
 } from '../../utils/shared';
 import { calculateNetherRoute } from '@/lib/nether/routing';
 import { callLinkedPortal } from '../route-utils';
-import type { RoutePoint } from '../route-types';
+import type { RoutePoint, RoutePortal, RoutePortalWithDistance } from '../route-types';
 
 export interface ResolvedNetherEndpoint {
-  linkedPortal: (Portal & { distance: number }) | null;
-  coordinates: Portal['coordinates'];
+  linkedPortal: RoutePortalWithDistance | null;
+  coordinates: RoutePortal['coordinates'];
   address?: string;
 }
 
 export async function resolveNetherEndpoint(
-  overworldPortal: Portal,
-  allPortals: Portal[]
+  overworldPortal: RoutePortal,
+  allPortals: RoutePortal[]
 ): Promise<ResolvedNetherEndpoint> {
   const linkedPortal = await callLinkedPortal(
     overworldPortal.coordinates.x,
@@ -60,7 +59,7 @@ export const toRoutePointStart = (point: RoutePoint) => ({
 });
 
 export const toPortalLocation = (
-  portal: Portal,
+  portal: RoutePortal,
   options: { world?: string; address?: string } = {}
 ) => ({
   id: portal.id,
@@ -81,7 +80,7 @@ export const toNetherEndpointLocation = (
 });
 
 interface NetherTransportLocation {
-  coordinates: Portal['coordinates'];
+  coordinates: RoutePortal['coordinates'];
 }
 
 export const buildNetherTransport = <

--- a/app/api/route/service/route-data.ts
+++ b/app/api/route/service/route-data.ts
@@ -1,0 +1,69 @@
+import { revalidateTag, unstable_cache } from 'next/cache';
+import { prisma } from '@/lib/prisma';
+import { normalizeLinkedPortalIdentities } from '@/lib/portal/linked-portals';
+import type { RouteDataSet, RouteEntity, RoutePortal } from '../route-types';
+
+const ROUTE_DATA_CACHE_TAG = 'route-data';
+
+const routeEntitySelect = {
+  slug: true,
+  name: true,
+  world: true,
+  coordX: true,
+  coordY: true,
+  coordZ: true,
+  address: true,
+} as const;
+
+const queryRouteData = async (): Promise<RouteDataSet> => {
+  const [placeRecords, portalRecords] = await Promise.all([
+    prisma.place.findMany({ select: routeEntitySelect }),
+    prisma.portal.findMany({
+      select: {
+        ...routeEntitySelect,
+        mapEntryId: true,
+      },
+    }),
+  ]);
+
+  const places = placeRecords.map((place): RouteEntity => ({
+    id: place.slug,
+    name: place.name,
+    world: place.world,
+    coordinates: {
+      x: place.coordX,
+      y: place.coordY,
+      z: place.coordZ,
+    },
+    address: place.address,
+  }));
+
+  const portals = portalRecords.map((portal): RoutePortal => ({
+    id: portal.slug,
+    slug: portal.slug,
+    name: portal.name,
+    world: portal.world,
+    coordinates: {
+      x: portal.coordX,
+      y: portal.coordY,
+      z: portal.coordZ,
+    },
+    address: portal.address ?? '',
+    mapEntryId: portal.mapEntryId,
+  }));
+
+  return {
+    places,
+    portals: normalizeLinkedPortalIdentities(portals),
+  };
+};
+
+const loadCachedRouteData = unstable_cache(
+  queryRouteData,
+  ['route-data-v1'],
+  { revalidate: 60, tags: [ROUTE_DATA_CACHE_TAG] },
+);
+
+export const loadRouteData = () => loadCachedRouteData();
+
+export const invalidateRouteData = () => revalidateTag(ROUTE_DATA_CACHE_TAG);

--- a/app/api/route/service/route-service.ts
+++ b/app/api/route/service/route-service.ts
@@ -1,10 +1,9 @@
 import { NextResponse } from 'next/server';
 import {
   calculateEuclideanDistance,
-  type Portal,
 } from '../../utils/shared';
-import { callNearestPortals } from '../route-utils';
-import type { RoutePoint } from '../route-types';
+import { callNearestPortal } from '../route-utils';
+import type { RoutePoint, RoutePortal } from '../route-types';
 import {
   buildNetherTransport,
   resolveNetherEndpoint,
@@ -15,11 +14,7 @@ import {
 } from './helpers';
 
 export class RouteService {
-  private portals: Portal[];
-
-  constructor(portals: Portal[]) {
-    this.portals = portals;
-  }
+  constructor(private readonly portals: RoutePortal[]) {}
 
   async handleOverworldToOverworld(fromPoint: RoutePoint, toPoint: RoutePoint) {
     const directDistance = calculateEuclideanDistance(
@@ -50,29 +45,27 @@ export class RouteService {
     
     // Option B: Via nether
     const searchRadius = directDistance;
-    const nearbyPortalsFrom = await callNearestPortals(
+    const portal1 = callNearestPortal(
       fromPoint.coordinates.x, fromPoint.coordinates.y, fromPoint.coordinates.z,
       'overworld', this.portals, searchRadius
     );
-    
-    if (nearbyPortalsFrom.length === 0) {
+
+    if (!portal1) {
       return NextResponse.json(directRoute);
     }
-    
-    const nearbyPortalsTo = await callNearestPortals(
+
+    const portal2 = callNearestPortal(
       toPoint.coordinates.x, toPoint.coordinates.y, toPoint.coordinates.z,
       'overworld', this.portals, searchRadius
     );
-    
-    if (nearbyPortalsTo.length === 0) {
+
+    if (!portal2) {
       return NextResponse.json(directRoute);
     }
-    
+
     // Try to find linked portals or calculate theoretical ones
-    const portal1 = nearbyPortalsFrom[0];
     const portal1NetherEndpoint = await resolveNetherEndpoint(portal1, this.portals);
 
-    const portal2 = nearbyPortalsTo[0];
     const portal2NetherEndpoint = await resolveNetherEndpoint(portal2, this.portals);
     const linkedPortal2 = portal2NetherEndpoint.linkedPortal;
 
@@ -148,19 +141,18 @@ export class RouteService {
   }
 
   async handleOverworldToNether(fromPoint: RoutePoint, toPoint: RoutePoint) {
-    const nearbyPortals = await callNearestPortals(
+    const portal = callNearestPortal(
       fromPoint.coordinates.x, fromPoint.coordinates.y, fromPoint.coordinates.z,
       'overworld', this.portals
     );
-    
-    if (nearbyPortals.length === 0) {
+
+    if (!portal) {
       return NextResponse.json(
         { error: 'No overworld portals found' },
         { status: 404 }
       );
     }
     
-    const portal = nearbyPortals[0];
     const netherEndpoint = await resolveNetherEndpoint(portal, this.portals);
     
     const distanceToPortal = portal.distance;
@@ -196,19 +188,18 @@ export class RouteService {
   }
 
   async handleNetherToOverworld(fromPoint: RoutePoint, toPoint: RoutePoint) {
-    const nearbyPortals = await callNearestPortals(
+    const portal = callNearestPortal(
       toPoint.coordinates.x, toPoint.coordinates.y, toPoint.coordinates.z,
       'overworld', this.portals
     );
-    
-    if (nearbyPortals.length === 0) {
+
+    if (!portal) {
       return NextResponse.json(
         { error: 'No overworld portals found near destination' },
         { status: 404 }
       );
     }
     
-    const portal = nearbyPortals[0];
     const netherEndpoint = await resolveNetherEndpoint(portal, this.portals);
     
     const netherTransport = buildNetherTransport(

--- a/components/PositionPanel.tsx
+++ b/components/PositionPanel.tsx
@@ -105,13 +105,20 @@ export default function PositionPanel({
     try {
       const data = await playerCoordsApi.getCoords();
       const nextWorld = normalizeWorldName(data.world);
-      setManualCoords({
+      const nextCoords = {
         x: String(Math.floor(data.x)),
         y: String(Math.floor(data.y)),
         z: String(Math.floor(data.z)),
-      });
+      };
+      setManualCoords((current) => (
+        current.x === nextCoords.x
+        && current.y === nextCoords.y
+        && current.z === nextCoords.z
+          ? current
+          : nextCoords
+      ));
       if (nextWorld) setManualWorld(nextWorld);
-      setPlayerData(data);
+      setPlayerData((current) => isSamePlayerData(current, data) ? current : data);
     } catch (err) {
       if (!isAutoSync && isMissingPlayerCoordsMod(err)) {
         setSyncError(null);
@@ -134,8 +141,18 @@ export default function PositionPanel({
   useEffect(() => {
     if (!isConnected) return;
 
-    const interval = setInterval(() => syncPosition(true), 2000);
-    return () => clearInterval(interval);
+    let cancelled = false;
+    let timeout: ReturnType<typeof setTimeout>;
+    const poll = async () => {
+      await syncPosition(true);
+      if (!cancelled) timeout = setTimeout(poll, 2000);
+    };
+
+    timeout = setTimeout(poll, 2000);
+    return () => {
+      cancelled = true;
+      clearTimeout(timeout);
+    };
   }, [isConnected, syncPosition]);
 
   useEffect(() => {
@@ -143,13 +160,14 @@ export default function PositionPanel({
   }, [playerData, onPlayerPositionChange]);
 
   useEffect(() => {
+    if (playerData) return;
     onManualCoordsChange?.({
       x: manualCoords.x,
       y: manualCoords.y,
       z: manualCoords.z,
       world: manualWorld,
     });
-  }, [manualCoords, manualWorld, onManualCoordsChange]);
+  }, [manualCoords, manualWorld, onManualCoordsChange, playerData]);
 
   const syncAction = (
     <PositionSyncButton
@@ -261,6 +279,15 @@ function handleSyncError(
 function isMissingPlayerCoordsMod(error: unknown) {
   return error instanceof PlayerCoordsApiError
     && error.type === PlayerCoordsApiErrorType.CONNECTION_FAILED;
+}
+
+function isSamePlayerData(current: PlayerData | null, next: PlayerData) {
+  return current?.x === next.x
+    && current.y === next.y
+    && current.z === next.z
+    && current.world === next.world
+    && current.uuid === next.uuid
+    && current.username === next.username;
 }
 
 function triggerSyncError(

--- a/components/route/useRoutePlan.ts
+++ b/components/route/useRoutePlan.ts
@@ -1,9 +1,10 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   buildRouteFromParams,
-  hasManualRouteCoordinates,
+  resolveRouteOrigin,
+  shouldRefreshRouteOrigin,
   type ManualRouteCoordinates,
   type PlayerRoutePosition,
   type RouteData,
@@ -15,98 +16,130 @@ interface UseRoutePlanParams {
   manualCoords?: ManualRouteCoordinates;
 }
 
+interface LatestRouteOrigin {
+  position: PlayerRoutePosition | null;
+  synced: boolean;
+}
+
 export function useRoutePlan({ selectedId, playerPosition, manualCoords }: UseRoutePlanParams) {
   const [route, setRoute] = useState<RouteData | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const routeRef = useRef<RouteData | null>(null);
+  const [requestOrigin, setRequestOrigin] = useState<PlayerRoutePosition | null>(null);
+  const inFlightRef = useRef(false);
+  const requestIdRef = useRef(0);
+  const selectedIdRef = useRef(selectedId);
+  const latestOriginRef = useRef<LatestRouteOrigin>({ position: null, synced: false });
+  selectedIdRef.current = selectedId;
+  const manualWorld = manualCoords?.world;
+  const manualX = manualCoords?.x;
+  const manualY = manualCoords?.y;
+  const manualZ = manualCoords?.z;
+  const playerWorld = playerPosition?.world;
+  const playerX = playerPosition?.x;
+  const playerY = playerPosition?.y;
+  const playerZ = playerPosition?.z;
+
+  const latestOrigin = useMemo(
+    () => resolveRouteOrigin(
+      playerWorld !== undefined
+        && playerX !== undefined
+        && playerY !== undefined
+        && playerZ !== undefined
+        ? { world: playerWorld, x: playerX, y: playerY, z: playerZ }
+        : null,
+      manualWorld
+        ? { world: manualWorld, x: manualX ?? '', y: manualY ?? '', z: manualZ ?? '' }
+        : undefined,
+    ),
+    [
+      manualWorld,
+      manualX,
+      manualY,
+      manualZ,
+      playerWorld,
+      playerX,
+      playerY,
+      playerZ,
+    ],
+  );
+  const isSynced = Boolean(playerPosition);
 
   useEffect(() => {
-    routeRef.current = route;
-  }, [route]);
+    const nextOrigin = { position: latestOrigin, synced: isSynced };
+    latestOriginRef.current = nextOrigin;
 
-  const shouldRecalculate = useCallback((currentRoute: RouteData | null) => {
-    if (!currentRoute || currentRoute.steps.length === 0) {
-      return true;
-    }
-
-    if (!playerPosition) {
-      return true;
-    }
-
-    const currentFrom = currentRoute.player_from.coordinates;
-    const distance = Math.sqrt(
-      Math.pow(playerPosition.x - currentFrom.x, 2) +
-      Math.pow(playerPosition.y - currentFrom.y, 2) +
-      Math.pow(playerPosition.z - currentFrom.z, 2)
-    );
-
-    if (distance >= 5) {
-      return true;
-    }
-
-    const lastStepTo = currentRoute.steps[currentRoute.steps.length - 1]?.to;
-    return lastStepTo?.id !== selectedId;
-  }, [playerPosition, selectedId]);
-
-  const calculateRoute = useCallback(async (signal: AbortSignal) => {
-    if (!selectedId) {
-      return;
-    }
-
-    try {
-      const fromParams = buildRouteFromParams(playerPosition, manualCoords);
-      if (!fromParams) {
-        return;
-      }
-
-      setLoading(true);
-      setError(null);
-
-      const response = await fetch(`/api/route?${fromParams}&to_place_id=${selectedId}`, { signal });
-      if (!response.ok) {
-        const errorText = await response.text();
-        throw new Error(`Erreur ${response.status}: ${errorText || "Impossible de calculer l'itinéraire"}`);
-      }
-
-      const data: RouteData = await response.json();
-      setRoute(data);
-    } catch (err) {
-      if (err instanceof DOMException && err.name === 'AbortError') {
-        return;
-      }
-
-      setError(err instanceof Error ? err.message : 'Erreur inconnue');
-      setRoute(null);
-    } finally {
-      if (!signal.aborted) {
-        setLoading(false);
-      }
-    }
-  }, [manualCoords, playerPosition, selectedId]);
-
-  useEffect(() => {
-    const hasOrigin = Boolean(playerPosition || hasManualRouteCoordinates(manualCoords));
-    if (!selectedId || !hasOrigin) {
+    if (!selectedId || !latestOrigin) {
+      setRequestOrigin(null);
       setRoute(null);
       setError(null);
       setLoading(false);
       return;
     }
 
-    if (!shouldRecalculate(routeRef.current)) {
-      return;
-    }
+    if (inFlightRef.current) return;
+    setRequestOrigin((current) => (
+      shouldRefreshRouteOrigin(current, nextOrigin.position, nextOrigin.synced)
+        ? latestOrigin
+        : current
+    ));
+  }, [isSynced, latestOrigin, selectedId]);
+
+  useEffect(() => {
+    if (!selectedId || !requestOrigin) return;
 
     const controller = new AbortController();
-    calculateRoute(controller.signal);
-    return () => controller.abort();
-  }, [calculateRoute, manualCoords, playerPosition, selectedId, shouldRecalculate]);
+    const requestId = ++requestIdRef.current;
+    inFlightRef.current = true;
+    setLoading(true);
+    setError(null);
+
+    const calculateRoute = async () => {
+      try {
+        const fromParams = buildRouteFromParams(requestOrigin);
+        const query = new URLSearchParams(fromParams ?? '');
+        query.set('to_place_id', selectedId);
+        const response = await fetch(`/api/route?${query}`, { signal: controller.signal });
+        if (!response.ok) {
+          const errorText = await response.text();
+          throw new Error(`Erreur ${response.status}: ${errorText || "Impossible de calculer l'itinéraire"}`);
+        }
+
+        const data: RouteData = await response.json();
+        if (requestId === requestIdRef.current) setRoute(data);
+      } catch (err) {
+        if (controller.signal.aborted) return;
+        if (requestId === requestIdRef.current) {
+          setError(err instanceof Error ? err.message : 'Erreur inconnue');
+          setRoute(null);
+        }
+      } finally {
+        if (!controller.signal.aborted && requestId === requestIdRef.current) {
+          inFlightRef.current = false;
+          setLoading(false);
+
+          const latest = latestOriginRef.current;
+          if (
+            selectedIdRef.current === selectedId
+            && shouldRefreshRouteOrigin(requestOrigin, latest.position, latest.synced)
+          ) {
+            setRequestOrigin(latest.position);
+          }
+        }
+      }
+    };
+
+    void calculateRoute();
+    return () => {
+      controller.abort();
+      inFlightRef.current = false;
+    };
+  }, [requestOrigin, selectedId]);
 
   return {
     route,
     loading,
     error,
-    hasOrigin: Boolean(playerPosition || hasManualRouteCoordinates(manualCoords)),
+    hasOrigin: Boolean(latestOrigin),
   };
 }

--- a/docs/BACKEND_API.md
+++ b/docs/BACKEND_API.md
@@ -221,12 +221,11 @@ Calculates the optimal route between two locations using the full routing algori
     - `parseQueryParams()` in `app/api/utils/api-utils.ts`
     - `handleError()` in `app/api/utils/api-utils.ts`
     - `normalizeWorldName()` in `lib/world-utils.ts`
-    - `loadPlaces()` in `app/api/utils/shared.ts`
-    - `loadPortals()` in `app/api/utils/shared.ts`
+    - `loadRouteData()` in `app/api/route/service/route-data.ts`
     - `RouteService` class in `app/api/route/service/route-service.ts`
 - **`route-service.ts` (Service):**
     - `RouteService` constructor is initialized with `portals`.
-    - `callNearestPortals()` in `app/api/route/route-utils.ts`
+    - `callNearestPortal()` in `app/api/route/route-utils.ts`
     - `callLinkedPortal()` in `app/api/route/route-utils.ts`
     - `calculateEuclideanDistance()` in `app/api/utils/shared.ts`
 - **Nether network:**
@@ -236,6 +235,16 @@ Calculates the optimal route between two locations using the full routing algori
 **Note:** You must provide either coordinates (`x`, `y`, `z`) or `place_id` for both source and destination.
 
 #### Internal Logic
+
+- Route data uses a dedicated projection containing only identifiers, worlds,
+  coordinates, addresses, and portal pairing identities. It does not load
+  images, trade offers, spaces, owners, managers, or editor metadata.
+- Place and portal projections are queried concurrently and cached for up to
+  60 seconds in the Next.js data cache. Successful place and portal mutations
+  invalidate the shared cache immediately.
+- Nearest and linked portal searches scan the projected portal collection once
+  and retain only the best candidate, without sorting or copying the complete
+  collection.
 
 - **`Overworld to Overworld`**: 
   1. Calculates direct euclidean distance.

--- a/lib/playercoords-api.ts
+++ b/lib/playercoords-api.ts
@@ -66,18 +66,16 @@ export class PlayerCoordsApi {
   /**
    * Get current player coordinates and world information
    * @returns Promise resolving to player data
-   * @throws PlayerCoordsApiError with categorized error types
-   */
+  * @throws PlayerCoordsApiError with categorized error types
+  */
   async getCoords(): Promise<PlayerData> {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), this.timeout);
+
     try {
-      const controller = new AbortController();
-      const timeoutId = setTimeout(() => controller.abort(), this.timeout);
-      
       const response = await fetch(`${this.baseUrl}/api/coords`, {
         signal: controller.signal
       });
-      
-      clearTimeout(timeoutId);
       
       if (!response.ok) {
         if (response.status === 404) {
@@ -140,6 +138,8 @@ export class PlayerCoordsApi {
         PlayerCoordsApiErrorType.UNKNOWN,
         rawErrorMessage
       );
+    } finally {
+      clearTimeout(timeoutId);
     }
   }
 

--- a/lib/route-planning/index.ts
+++ b/lib/route-planning/index.ts
@@ -29,27 +29,51 @@ export type {
 export const hasManualRouteCoordinates = (manualCoords?: ManualRouteCoordinates) =>
   Boolean(manualCoords?.x && manualCoords?.y && manualCoords?.z);
 
-export const buildRouteFromParams = (
+export const resolveRouteOrigin = (
   playerPosition?: PlayerRoutePosition | null,
-  manualCoords?: ManualRouteCoordinates
-) => {
-  if (playerPosition) {
-    return `from_x=${playerPosition.x}&from_y=${playerPosition.y}&from_z=${playerPosition.z}&from_world=${playerPosition.world}`;
-  }
-
-  if (!hasManualRouteCoordinates(manualCoords)) {
-    return null;
-  }
+  manualCoords?: ManualRouteCoordinates,
+): PlayerRoutePosition | null => {
+  if (playerPosition) return playerPosition;
+  if (!hasManualRouteCoordinates(manualCoords)) return null;
 
   const x = Number.parseFloat(manualCoords!.x);
   const y = Number.parseFloat(manualCoords!.y);
   const z = Number.parseFloat(manualCoords!.z);
+  if ([x, y, z].some(Number.isNaN)) return null;
 
-  if (Number.isNaN(x) || Number.isNaN(y) || Number.isNaN(z)) {
-    throw new Error('Coordonnées invalides');
-  }
+  return { x, y, z, world: manualCoords!.world };
+};
 
-  return `from_x=${x}&from_y=${y}&from_z=${z}&from_world=${manualCoords!.world}`;
+export const shouldRefreshRouteOrigin = (
+  current: PlayerRoutePosition | null,
+  latest: PlayerRoutePosition | null,
+  synced: boolean,
+  syncedDistance = 5,
+) => {
+  if (!latest) return false;
+  if (!current || current.world !== latest.world) return true;
+
+  const distance = Math.hypot(
+    latest.x - current.x,
+    latest.y - current.y,
+    latest.z - current.z,
+  );
+  return synced ? distance >= syncedDistance : distance > 0;
+};
+
+export const buildRouteFromParams = (
+  playerPosition?: PlayerRoutePosition | null,
+  manualCoords?: ManualRouteCoordinates
+) => {
+  const origin = resolveRouteOrigin(playerPosition, manualCoords);
+  if (!origin) return null;
+
+  return new URLSearchParams({
+    from_x: String(origin.x),
+    from_y: String(origin.y),
+    from_z: String(origin.z),
+    from_world: origin.world,
+  }).toString();
 };
 
 export const getRouteTransportSteps = (route: RouteData) =>

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -14,6 +14,13 @@ jest.mock('../app/api/utils/shared', () => ({
   loadPortals: jest.fn(() => Promise.resolve(mockPortals))
 }));
 
+jest.mock('../app/api/route/service/route-data', () => ({
+  loadRouteData: jest.fn(() => Promise.resolve({
+    places: mockPlaces,
+    portals: mockPortals,
+  })),
+}));
+
 describe('API Endpoints', () => {
   describe('/api/nether-address', () => {
     it('should calculate nether address for overworld coordinates', async () => {

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -9,6 +9,13 @@ jest.mock('../app/api/utils/shared', () => ({
   loadPortals: jest.fn(() => Promise.resolve(mockPortals))
 }));
 
+jest.mock('../app/api/route/service/route-data', () => ({
+  loadRouteData: jest.fn(() => Promise.resolve({
+    places: mockPlaces,
+    portals: mockPortals,
+  })),
+}));
+
 describe('Route API Integration Tests - Real Behavior Validation', () => {
   
   describe('Overworld to Overworld Routes', () => {

--- a/tests/route-planning.test.ts
+++ b/tests/route-planning.test.ts
@@ -1,4 +1,9 @@
-import { buildRouteBreadcrumb, type RouteData } from '../lib/route-planning';
+import {
+  buildRouteBreadcrumb,
+  resolveRouteOrigin,
+  shouldRefreshRouteOrigin,
+  type RouteData,
+} from '../lib/route-planning';
 
 describe('buildRouteBreadcrumb', () => {
   it('adds the nether address to an overworld portal waypoint before a portal crossing', () => {
@@ -251,5 +256,42 @@ describe('buildRouteBreadcrumb', () => {
         coordinates: { x: 128, y: 74, z: -2616 },
       },
     ]);
+  });
+});
+
+describe('route request origins', () => {
+  const origin = { x: 10, y: 70, z: 20, world: 'overworld' };
+
+  it('prioritizes the synchronized player position over manual coordinates', () => {
+    expect(resolveRouteOrigin(origin, {
+      x: '100',
+      y: '80',
+      z: '200',
+      world: 'nether',
+    })).toBe(origin);
+  });
+
+  it('does not refresh a synchronized route below the movement threshold', () => {
+    expect(shouldRefreshRouteOrigin(
+      origin,
+      { ...origin, x: 14.9 },
+      true,
+    )).toBe(false);
+  });
+
+  it('refreshes a synchronized route at the movement threshold', () => {
+    expect(shouldRefreshRouteOrigin(
+      origin,
+      { ...origin, x: 15 },
+      true,
+    )).toBe(true);
+  });
+
+  it('refreshes manual coordinates after any actual change', () => {
+    expect(shouldRefreshRouteOrigin(
+      origin,
+      { ...origin, z: 20.1 },
+      false,
+    )).toBe(true);
   });
 });


### PR DESCRIPTION
- Prevent PCAPI updates from continuously cancelling active route calculations.
- Serialize position polling and recalculations while retaining the latest position.
- Load only the Prisma fields required by the routing algorithm.
- Cache routing data and invalidate it after place or portal mutations.
- Optimize portal searches and update the related tests and backend documentation.