### PR TITLE
Simplify Discord authentication persistence

### DIFF
--- a/app/api/admin/users/route.ts
+++ b/app/api/admin/users/route.ts
@@ -10,6 +10,10 @@ import { MANAGEMENT_LIST_PAGE_SIZE } from '@/lib/management/pagination';
 import { isAdministrationRole } from '@/lib/admin/roles';
 import { getEffectiveRequestRole } from '@/lib/admin/request-role';
 import { normalizeDiscordUserQuery } from '@/lib/discord/user-search';
+import {
+  discordIdentitySelect,
+  toPublicDiscordIdentity,
+} from '@/lib/discord-user';
 
 const querySchema = z.object({
   page: z.coerce.number().int().min(1).default(1),
@@ -49,10 +53,7 @@ export async function GET(request: NextRequest) {
       skip: (page - 1) * MANAGEMENT_LIST_PAGE_SIZE,
       take: MANAGEMENT_LIST_PAGE_SIZE,
       select: {
-        id: true,
-        name: true,
-        username: true,
-        image: true,
+        ...discordIdentitySelect,
         role: true,
         minecraftProfile: {
           select: {
@@ -69,10 +70,7 @@ export async function GET(request: NextRequest) {
 
   const response: AdminUsersResponse = {
     users: users.map((user) => ({
-      id: user.id,
-      name: user.name,
-      username: user.username,
-      image: user.image,
+      ...toPublicDiscordIdentity(user),
       role: user.role,
       minecraftUuid: user.minecraftProfile?.uuid ?? null,
       minecraftName: user.minecraftProfile?.name ?? null,
@@ -94,7 +92,7 @@ function getUserSearchFilters(query: string): Prisma.UserWhereInput[] {
   const text = { contains: query, mode: Prisma.QueryMode.insensitive };
   const discordQuery = normalizeDiscordUserQuery(query);
   const filters: Prisma.UserWhereInput[] = [
-    { name: text },
+    { discordDisplayName: text },
     { id: text },
     { minecraftProfile: { is: { name: text } } },
     { minecraftProfile: { is: { uuid: text } } },
@@ -102,14 +100,14 @@ function getUserSearchFilters(query: string): Prisma.UserWhereInput[] {
 
   if (discordQuery) {
     filters.push({
-      username: {
+      discordUsername: {
         contains: discordQuery,
         mode: Prisma.QueryMode.insensitive,
       },
     });
   }
   if (matchesDisplayedLabel('Utilisateur', query)) {
-    filters.push({ name: null });
+    filters.push({ discordDisplayName: null });
   }
   if (matchesDisplayedLabel('Non lié', query)) {
     filters.push({ minecraftProfile: { is: null } });

--- a/app/api/users/search/route.ts
+++ b/app/api/users/search/route.ts
@@ -4,6 +4,10 @@ import { auth } from '@/auth';
 import { getEffectiveRequestRole } from '@/lib/admin/request-role';
 import { canContribute } from '@/lib/content-permissions';
 import { normalizeDiscordUserQuery } from '@/lib/discord/user-search';
+import {
+  discordIdentitySelect,
+  toPublicDiscordIdentity,
+} from '@/lib/discord-user';
 import { prisma } from '@/lib/prisma';
 import type { MapEntryUser } from '@/lib/map-entry/types';
 
@@ -34,17 +38,14 @@ export async function GET(request: NextRequest) {
     where: {
       role: { in: ['user', 'admin', 'super_admin'] },
       OR: [
-        { name: { contains: parsed.data.query, mode: 'insensitive' } },
-        { username: { contains: parsed.data.query, mode: 'insensitive' } },
+        { discordDisplayName: { contains: parsed.data.query, mode: 'insensitive' } },
+        { discordUsername: { contains: parsed.data.query, mode: 'insensitive' } },
       ],
     },
-    orderBy: [{ name: 'asc' }, { username: 'asc' }],
+    orderBy: [{ discordDisplayName: 'asc' }, { discordUsername: 'asc' }],
     take: 8,
     select: {
-      id: true,
-      name: true,
-      username: true,
-      image: true,
+      ...discordIdentitySelect,
       role: true,
       minecraftProfile: {
         select: { uuid: true, name: true },
@@ -52,5 +53,11 @@ export async function GET(request: NextRequest) {
     },
   });
 
-  return NextResponse.json({ users: users satisfies MapEntryUser[] });
+  return NextResponse.json({
+    users: users.map((user) => ({
+      ...toPublicDiscordIdentity(user),
+      role: user.role,
+      minecraftProfile: user.minecraftProfile,
+    })) satisfies MapEntryUser[],
+  });
 }

--- a/auth.ts
+++ b/auth.ts
@@ -1,20 +1,8 @@
-import { PrismaAdapter } from '@auth/prisma-adapter';
 import NextAuth from 'next-auth';
 import Discord from 'next-auth/providers/discord';
-import { applyApprovalPolicyToCreatedUser } from '@/lib/admin/application-settings-service';
 import { authCallbacks } from '@/lib/auth/callbacks';
-import { prisma } from '@/lib/prisma';
-
-const prismaAdapter = PrismaAdapter(prisma);
-const createPrismaUser = prismaAdapter.createUser!;
 
 export const { handlers, signIn, signOut, auth } = NextAuth({
-  adapter: {
-    ...prismaAdapter,
-    createUser: async (user) => applyApprovalPolicyToCreatedUser(
-      await createPrismaUser(user),
-    ),
-  },
   trustHost: true,
   session: {
     strategy: 'jwt',
@@ -26,6 +14,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
     Discord({
       clientId: process.env.DISCORD_CLIENT_ID!,
       clientSecret: process.env.DISCORD_CLIENT_SECRET!,
+      authorization: { params: { scope: 'identify' } },
     }),
   ],
   callbacks: authCallbacks,

--- a/components/SettingsPanel.tsx
+++ b/components/SettingsPanel.tsx
@@ -152,7 +152,7 @@ export default function SettingsPanel({
                     <span className="flex w-6 shrink-0 justify-center">
                       <SettingsIcon className="h-4 w-4" />
                     </span>
-                    Gérer les paramètres
+                    Gérer mes paramètres
                   </PillActionButton>
                   <AddContentButton fullWidth className="h-10 !py-0">
                     <span className="flex w-6 shrink-0 justify-center">

--- a/docs/BACKEND_API.md
+++ b/docs/BACKEND_API.md
@@ -417,6 +417,27 @@ curl "http://localhost:3000/api/route?from_x=1000&from_y=65&from_z=-500&from_wor
 
 ---
 
+## Discord Authentication
+
+Discord OAuth requests only the `identify` scope. PMC Plan never requests or
+stores the user's email address. The returned Discord snowflake is the stable
+external identifier; usernames remain editable display data and are not used
+as database keys.
+
+The OAuth callback upserts the application user by `discordId`, refreshes the
+username, display name, and avatar URL, then stores the internal user ID and
+role in the signed Auth.js JWT. Existing roles are never changed during a
+subsequent login. The approval setting only determines the role assigned in
+the create branch.
+
+No Auth.js database adapter is used. Discord access and refresh tokens stay in
+the transient OAuth callback and are discarded afterwards. PostgreSQL stores
+only the internal user ID, Discord identity fields, role, creation date, and
+application relations. The public session and API serializers keep exposing
+the compact `name`, `username`, and `image` shape expected by the frontend.
+
+---
+
 ## Account Approval and Content Authorization
 
 New Discord accounts are stored with the `pending` role when manual approval is
@@ -528,8 +549,7 @@ administration view. The authenticated session must have the `admin` or
 - Validates and normalizes query parameters with Zod.
 - Reads users in reverse registration order with 7 records per page.
 - Runs the page query and total count in one Prisma transaction.
-- Returns only account summary fields; OAuth tokens and session records are
-  never exposed.
+- Returns only account summary fields; OAuth tokens are never persisted.
 
 **Response:**
 ```json
@@ -720,8 +740,8 @@ manager of one or more map entries or spaces.
   already present.
 - Deletes against the previously read role to prevent a concurrent role change
   from bypassing the hierarchy.
-- Deletes related OAuth accounts, sessions, and Minecraft linking requests
-  through Prisma cascading relations.
+- Deletes related Minecraft linking requests through Prisma cascading
+  relations. Authentication has no separate account or session rows.
 - Returns the updated management records for every affected map entry so the
   client can patch its caches without reloading the map.
 

--- a/lib/admin/application-settings-service.ts
+++ b/lib/admin/application-settings-service.ts
@@ -1,4 +1,4 @@
-import type { AdapterUser } from '@auth/core/adapters';
+import type { Role } from '@prisma/client';
 import { prisma } from '@/lib/prisma';
 import {
   DEFAULT_APPLICATION_SETTINGS,
@@ -26,18 +26,7 @@ export async function saveApplicationSettings(
   });
 }
 
-export async function applyApprovalPolicyToCreatedUser(
-  user: AdapterUser,
-): Promise<AdapterUser> {
-  if (user.role !== 'pending') return user;
-
+export async function getInitialUserRole(): Promise<Role> {
   const settings = await getApplicationSettings();
-  if (!settings.automaticUserApproval) return user;
-
-  const approvedUser = await prisma.user.update({
-    where: { id: user.id },
-    data: { role: 'user' },
-    select: { role: true },
-  });
-  return { ...user, role: approvedUser.role };
+  return settings.automaticUserApproval ? 'user' : 'pending';
 }

--- a/lib/auth/callbacks.ts
+++ b/lib/auth/callbacks.ts
@@ -1,32 +1,32 @@
-import type { User } from '@prisma/client';
 import type { NextAuthConfig } from 'next-auth';
 import type { JWT } from 'next-auth/jwt';
-import { getDiscordDisplayName, getDiscordImage } from '@/lib/discord-user';
+import {
+  syncDiscordUser,
+  toPublicDiscordIdentity,
+} from '@/lib/discord-user';
 import { prisma } from '@/lib/prisma';
 import type { DiscordProfile } from '@/types/discord-profile';
 
 export const authCallbacks = {
   async jwt({ token, user, account, profile }) {
-    if (user) {
-      token.role = (user as User).role;
-      token.id = user.id as string;
+    if (account?.provider === 'discord' && profile) {
+      const storedUser = await syncDiscordUser(
+        toDiscordProfile(profile),
+        user?.image,
+      );
+      const identity = toPublicDiscordIdentity(storedUser);
+      token.id = storedUser.id;
+      token.role = storedUser.role;
+      token.username = identity.username;
+      token.globalName = identity.name;
+      token.name = identity.name;
+      token.picture = identity.image ?? undefined;
     } else if (token.id) {
       const currentUser = await prisma.user.findUnique({
         where: { id: token.id },
         select: { role: true },
       });
       token.role = currentUser?.role ?? 'pending';
-    }
-
-    if (account?.provider === 'discord' && profile) {
-      const discordIdentity = await syncDiscordIdentity(
-        user as User | undefined,
-        profile as DiscordProfile
-      );
-      token.username = discordIdentity.username ?? token.username;
-      token.globalName = discordIdentity.displayName ?? token.globalName;
-      token.name = discordIdentity.displayName ?? token.name;
-      if (discordIdentity.image) token.picture = discordIdentity.image;
     }
 
     return token;
@@ -43,38 +43,17 @@ export const authCallbacks = {
   },
 } satisfies NonNullable<NextAuthConfig['callbacks']>;
 
-async function syncDiscordIdentity(user: User | undefined, profile: DiscordProfile) {
-  const displayName = getDiscordDisplayName(profile);
-  const image = getDiscordImage(profile);
-
-  if (user) {
-    const updates: {
-      username?: string;
-      name?: string | null;
-      image?: string | null;
-    } = {};
-
-    if (profile.username && profile.username !== user.username) {
-      updates.username = profile.username;
-    }
-    if (displayName && displayName !== user.name) {
-      updates.name = displayName;
-    }
-    if (image !== (user.image ?? null)) {
-      updates.image = image;
-    }
-
-    if (Object.keys(updates).length > 0) {
-      await prisma.user.update({
-        where: { id: user.id },
-        data: updates,
-      });
-    }
+function toDiscordProfile(profile: Record<string, unknown>): DiscordProfile {
+  if (typeof profile.id !== 'string' || typeof profile.username !== 'string') {
+    throw new Error('Discord returned an incomplete identity.');
   }
 
   return {
+    id: profile.id,
     username: profile.username,
-    displayName,
-    image,
+    global_name: typeof profile.global_name === 'string'
+      ? profile.global_name
+      : null,
+    avatar: typeof profile.avatar === 'string' ? profile.avatar : null,
   };
 }

--- a/lib/content-management/filters.ts
+++ b/lib/content-management/filters.ts
@@ -27,8 +27,8 @@ export function getMapEntryWhere(
     : [{ space: { is: { name: text } } }];
   const discordManagerSearch: Prisma.MapEntryWhereInput[] = discordQuery
     ? [
-        { primaryManager: { is: { username: discordText } } },
-        { managers: { some: { user: { is: { username: discordText } } } } },
+        { primaryManager: { is: { discordUsername: discordText } } },
+        { managers: { some: { user: { is: { discordUsername: discordText } } } } },
       ]
     : [];
 
@@ -36,7 +36,7 @@ export function getMapEntryWhere(
     OR: [
       getContentSearch(type, text),
       ...contextSearch,
-      { primaryManager: { is: { name: text } } },
+      { primaryManager: { is: { discordDisplayName: text } } },
       ...discordManagerSearch,
     ],
   });
@@ -54,15 +54,15 @@ export function getSpaceWhere(
     const discordText = searchText(discordQuery);
     const discordManagerSearch: Prisma.SpaceWhereInput[] = discordQuery
       ? [
-          { primaryManager: { is: { username: discordText } } },
-          { managers: { some: { user: { is: { username: discordText } } } } },
+          { primaryManager: { is: { discordUsername: discordText } } },
+          { managers: { some: { user: { is: { discordUsername: discordText } } } } },
         ]
       : [];
     constraints.push({
       OR: [
         { name: text },
         { slug: text },
-        { primaryManager: { is: { name: text } } },
+        { primaryManager: { is: { discordDisplayName: text } } },
         ...discordManagerSearch,
       ],
     });

--- a/lib/content-management/query.ts
+++ b/lib/content-management/query.ts
@@ -10,6 +10,7 @@ import { MANAGEMENT_LIST_PAGE_SIZE } from '@/lib/management/pagination';
 import {
   publicMapEntryInclude,
 } from '@/lib/map-entry/serialization';
+import { toPublicDiscordIdentity } from '@/lib/discord-user';
 import { DEFAULT_PLACE_CATEGORY, isPlaceCategory } from '@/lib/place/categories';
 import { getMapEntryWhere, getSpaceWhere } from './filters';
 
@@ -89,7 +90,7 @@ function toMapEntrySummary(
   const common = {
     id: record.id,
     managerCount: record._count.managers,
-    primaryManager: record.primaryManager,
+    primaryManager: toPublicDiscordIdentity(record.primaryManager),
   };
   if (type === 'place' && record.place) {
     return [{
@@ -183,7 +184,7 @@ async function listSpaces(
     ),
     placeCount: record.entries.filter(({ place }) => place).length,
     portalCount: record.entries.filter(({ portals }) => portals.length > 0).length,
-    primaryManager: record.primaryManager,
+    primaryManager: toPublicDiscordIdentity(record.primaryManager),
     slug: record.slug,
   })));
 }

--- a/lib/discord-user.ts
+++ b/lib/discord-user.ts
@@ -1,13 +1,20 @@
+import type { Prisma } from '@prisma/client';
+import { getInitialUserRole } from '@/lib/admin/application-settings-service';
+import { prisma } from '@/lib/prisma';
 import type { DiscordProfile } from '@/types/discord-profile';
 
-export const getDiscordDisplayName = (profile: DiscordProfile) =>
-  profile.global_name?.trim() || profile.username?.trim() || profile.name?.trim() || null;
+export const discordIdentitySelect = {
+  id: true,
+  discordUsername: true,
+  discordDisplayName: true,
+  discordAvatarUrl: true,
+} satisfies Prisma.UserSelect;
+
+export type StoredDiscordIdentity = Prisma.UserGetPayload<{
+  select: typeof discordIdentitySelect;
+}>;
 
 export const getDiscordImage = (profile: DiscordProfile) => {
-  if (profile.image_url?.trim()) {
-    return profile.image_url.trim();
-  }
-
   if (profile.id && profile.avatar) {
     const format = profile.avatar.startsWith('a_') ? 'gif' : 'png';
     return `https://cdn.discordapp.com/avatars/${profile.id}/${profile.avatar}.${format}`;
@@ -15,3 +22,38 @@ export const getDiscordImage = (profile: DiscordProfile) => {
 
   return null;
 };
+
+export const toPublicDiscordIdentity = (user: StoredDiscordIdentity) => ({
+  id: user.id,
+  name: user.discordDisplayName ?? user.discordUsername,
+  username: user.discordUsername,
+  image: user.discordAvatarUrl,
+});
+
+export async function syncDiscordUser(
+  profile: DiscordProfile,
+  providerImage?: string | null,
+) {
+  const discordUsername = profile.username.trim();
+  if (!profile.id || !discordUsername) {
+    throw new Error('Discord returned an incomplete identity.');
+  }
+
+  const identity = {
+    discordUsername,
+    discordDisplayName: profile.global_name?.trim() || null,
+    discordAvatarUrl: getDiscordImage(profile) ?? providerImage ?? null,
+  };
+  const initialRole = await getInitialUserRole();
+
+  return prisma.user.upsert({
+    where: { discordId: profile.id },
+    create: {
+      discordId: profile.id,
+      ...identity,
+      role: initialRole,
+    },
+    update: identity,
+    select: { ...discordIdentitySelect, role: true },
+  });
+}

--- a/lib/map-entry/management-update.ts
+++ b/lib/map-entry/management-update.ts
@@ -54,7 +54,7 @@ export async function updateMapEntryManagement(
     select: {
       id: true,
       role: true,
-      username: true,
+      discordUsername: true,
       minecraftProfile: { select: { uuid: true, name: true } },
     },
   });
@@ -74,8 +74,7 @@ export async function updateMapEntryManagement(
 
   if (primaryManagerId !== entry.primaryManagerId) {
     if (
-      !primaryManager.username
-      || input.transferConfirmation !== `@${primaryManager.username}`
+      input.transferConfirmation !== `@${primaryManager.discordUsername}`
     ) {
       throw new MapEntryError(
         'La confirmation ne correspond pas à l’identifiant Discord.',

--- a/lib/map-entry/serialization.ts
+++ b/lib/map-entry/serialization.ts
@@ -7,11 +7,14 @@ import type {
   MinecraftOwner,
 } from './types';
 import type { SpaceReference } from '@/lib/spaces/types';
+import {
+  discordIdentitySelect,
+  type StoredDiscordIdentity,
+  toPublicDiscordIdentity,
+} from '@/lib/discord-user';
 import { prioritizePrimaryManagerOwner } from './owners';
 
-type MapEntryEditorIdentity = Omit<MapEntryEditor, 'editedAt'>;
-
-interface PublicPrimaryManagerRecord extends MapEntryEditorIdentity {
+interface PublicPrimaryManagerRecord extends StoredDiscordIdentity {
   minecraftProfile: MinecraftOwner | null;
 }
 
@@ -20,17 +23,13 @@ interface PublicMapEntryRecord {
   primaryManagerId: string;
   updatedAt: Date;
   primaryManager: PublicPrimaryManagerRecord;
-  lastEditor: MapEntryEditorIdentity | null;
+  lastEditor: StoredDiscordIdentity | null;
   managers: Array<{ userId: string }>;
   owners: Array<{ profile: MinecraftOwner }>;
   space: SpaceReference | null;
 }
 
-interface ManagementUserRecord {
-  id: string;
-  name: string | null;
-  username: string | null;
-  image: string | null;
+interface ManagementUserRecord extends StoredDiscordIdentity {
   role: MapEntryUser['role'];
   minecraftProfile: MinecraftOwner | null;
 }
@@ -46,22 +45,14 @@ interface ManagementMapEntryRecord extends PublicMapEntryRecord {
 export const publicMapEntryInclude = {
   primaryManager: {
     select: {
-      id: true,
-      name: true,
-      username: true,
-      image: true,
+      ...discordIdentitySelect,
       minecraftProfile: {
         select: { uuid: true, name: true },
       },
     },
   },
   lastEditor: {
-    select: {
-      id: true,
-      name: true,
-      username: true,
-      image: true,
-    },
+    select: discordIdentitySelect,
   },
   managers: {
     select: { userId: true },
@@ -91,10 +82,7 @@ export const publicMapEntryInclude = {
 export const managementMapEntryInclude = {
   primaryManager: {
     select: {
-      id: true,
-      name: true,
-      username: true,
-      image: true,
+      ...discordIdentitySelect,
       role: true,
       minecraftProfile: {
         select: { uuid: true, name: true },
@@ -108,10 +96,7 @@ export const managementMapEntryInclude = {
       userId: true,
       user: {
         select: {
-          id: true,
-          name: true,
-          username: true,
-          image: true,
+          ...discordIdentitySelect,
           role: true,
           minecraftProfile: {
             select: { uuid: true, name: true },
@@ -143,10 +128,7 @@ export function toMinecraftOwners(entry: PublicMapEntryRecord): MinecraftOwner[]
 export function toMapEntryEditor(entry: PublicMapEntryRecord): MapEntryEditor {
   const editor = entry.lastEditor ?? entry.primaryManager;
   return {
-    id: editor.id,
-    name: editor.name,
-    username: editor.username,
-    image: editor.image,
+    ...toPublicDiscordIdentity(editor),
     editedAt: entry.updatedAt,
   };
 }
@@ -154,8 +136,7 @@ export function toMapEntryEditor(entry: PublicMapEntryRecord): MapEntryEditor {
 export function toMapEntryPrimaryManager(
   entry: PublicMapEntryRecord,
 ): MapEntryIdentity {
-  const { id, image, name, username } = entry.primaryManager;
-  return { id, image, name, username };
+  return toPublicDiscordIdentity(entry.primaryManager);
 }
 
 export function toMapEntrySpace(
@@ -168,8 +149,16 @@ export function toMapEntryManagement(entry: ManagementMapEntryRecord): MapEntryM
   return {
     access: toMapEntryAccess(entry),
     lastEditor: toMapEntryEditor(entry),
-    primaryManager: entry.primaryManager,
-    managers: entry.managers.map(({ user }) => user),
+    primaryManager: toManagementUser(entry.primaryManager),
+    managers: entry.managers.map(({ user }) => toManagementUser(user)),
     owners: toMinecraftOwners(entry),
+  };
+}
+
+function toManagementUser(user: ManagementUserRecord): MapEntryUser {
+  return {
+    ...toPublicDiscordIdentity(user),
+    role: user.role,
+    minecraftProfile: user.minecraftProfile,
   };
 }

--- a/lib/spaces/serialization.ts
+++ b/lib/spaces/serialization.ts
@@ -1,22 +1,18 @@
 import type { Prisma } from '@prisma/client';
 import { sortByLocalizedName } from '@/lib/content/sorting';
+import {
+  discordIdentitySelect,
+  toPublicDiscordIdentity,
+} from '@/lib/discord-user';
 import { prioritizePrimaryManagerOwner } from '@/lib/map-entry/owners';
 import type { Space } from './types';
 
 const spaceUserSelect = {
-  id: true,
-  name: true,
-  username: true,
-  image: true,
+  ...discordIdentitySelect,
   role: true,
 } satisfies Prisma.UserSelect;
 
-const spaceEditorSelect = {
-  id: true,
-  name: true,
-  username: true,
-  image: true,
-} satisfies Prisma.UserSelect;
+const spaceEditorSelect = discordIdentitySelect;
 
 export const spaceInclude = {
   primaryManager: { select: spaceUserSelect },
@@ -142,13 +138,16 @@ export function toSpace(record: SpaceRecord): Space {
     ).values())),
     primaryManagerId: record.primaryManagerId,
     managerIds: record.managers.map(({ userId }) => userId),
-    primaryManager: record.primaryManager,
-    managers: record.managers.map(({ user }) => user),
+    primaryManager: {
+      ...toPublicDiscordIdentity(record.primaryManager),
+      role: record.primaryManager.role,
+    },
+    managers: record.managers.map(({ user }) => ({
+      ...toPublicDiscordIdentity(user),
+      role: user.role,
+    })),
     lastEditor: {
-      id: lastEditor.id,
-      name: lastEditor.name,
-      username: lastEditor.username,
-      image: lastEditor.image,
+      ...toPublicDiscordIdentity(lastEditor),
       editedAt: record.updatedAt.toISOString(),
     },
     createdAt: record.createdAt.toISOString(),

--- a/lib/spaces/service.ts
+++ b/lib/spaces/service.ts
@@ -153,7 +153,7 @@ export function transferSpace(
 
     const nextPrimary = await tx.user.findUnique({
       where: { id: nextPrimaryManagerId },
-      select: { role: true, username: true },
+      select: { role: true, discordUsername: true },
     });
     if (!nextPrimary || !canContribute(nextPrimary.role)) {
       throw new SpaceError(
@@ -162,8 +162,7 @@ export function transferSpace(
       );
     }
     if (
-      !nextPrimary.username
-      || confirmation !== `@${nextPrimary.username}`
+      confirmation !== `@${nextPrimary.discordUsername}`
     ) {
       throw new SpaceError(
         'La confirmation ne correspond pas à l’identifiant Discord.',

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "pmc-plan",
       "version": "1.0.0",
       "dependencies": {
-        "@auth/prisma-adapter": "^2.11.1",
         "@prisma/client": "^6.18.0",
         "@vercel/analytics": "^1.5.0",
         "next": "15.5.9",
@@ -65,47 +64,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@auth/core": {
-      "version": "0.41.1",
-      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.41.1.tgz",
-      "integrity": "sha512-t9cJ2zNYAdWMacGRMT6+r4xr1uybIdmYa49calBPeTqwgAFPV/88ac9TEvCR85pvATiSPt8VaNf+Gt24JIT/uw==",
-      "license": "ISC",
-      "dependencies": {
-        "@panva/hkdf": "^1.2.1",
-        "jose": "^6.0.6",
-        "oauth4webapi": "^3.3.0",
-        "preact": "10.24.3",
-        "preact-render-to-string": "6.5.11"
-      },
-      "peerDependencies": {
-        "@simplewebauthn/browser": "^9.0.1",
-        "@simplewebauthn/server": "^9.0.2",
-        "nodemailer": "^7.0.7"
-      },
-      "peerDependenciesMeta": {
-        "@simplewebauthn/browser": {
-          "optional": true
-        },
-        "@simplewebauthn/server": {
-          "optional": true
-        },
-        "nodemailer": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@auth/prisma-adapter": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/@auth/prisma-adapter/-/prisma-adapter-2.11.1.tgz",
-      "integrity": "sha512-Ke7DXP0Fy0Mlmjz/ZJLXwQash2UkA4621xCM0rMtEczr1kppLc/njCbUkHkIQ/PnmILjqSPEKeTjDPsYruvkug==",
-      "license": "ISC",
-      "dependencies": {
-        "@auth/core": "0.41.1"
-      },
-      "peerDependencies": {
-        "@prisma/client": ">=2.26.0 || >=3 || >=4 || >=5 || >=6"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "db:studio": "dotenv -e .env.local -- prisma studio"
   },
   "dependencies": {
-    "@auth/prisma-adapter": "^2.11.1",
     "@prisma/client": "^6.18.0",
     "@vercel/analytics": "^1.5.0",
     "next": "15.5.9",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -11,19 +11,15 @@ datasource db {
   directUrl = env("POSTGRES_URL_NON_POOLING")
 }
 
-// User model - minimal for Discord OAuth
 model User {
-  id            String    @id @default(cuid())
-  email         String?   @unique
-  name          String?
-  username      String?   @unique
-  image         String?
-  emailVerified DateTime?
-  role          Role      @default(pending)
-  createdAt     DateTime  @default(now())
-  updatedAt     DateTime  @updatedAt
+  id                 String   @id @default(cuid())
+  discordId          String   @unique @map("discord_id")
+  discordUsername    String   @map("discord_username")
+  discordDisplayName String?  @map("discord_display_name")
+  discordAvatarUrl   String?  @map("discord_avatar_url")
+  role               Role     @default(pending)
+  createdAt          DateTime @default(now()) @map("created_at")
 
-  accounts              Account[]
   minecraftLinkRequests MinecraftLinkRequest[]
   minecraftProfile      MinecraftProfile?      @relation("LinkedMinecraftProfile")
   primaryManagedEntries MapEntry[]             @relation("PrimaryMapEntryManager")
@@ -42,27 +38,6 @@ model ApplicationSettings {
   updatedAt             DateTime @updatedAt @map("updated_at")
 
   @@map("application_settings")
-}
-
-// Account model - stores Discord OAuth connection
-model Account {
-  id                String  @id @default(cuid())
-  userId            String  @map("user_id")
-  type              String
-  provider          String
-  providerAccountId String  @map("provider_account_id")
-  refresh_token     String? @db.Text
-  access_token      String? @db.Text
-  expires_at        Int?
-  token_type        String?
-  scope             String?
-  id_token          String? @db.Text
-  session_state     String?
-
-  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
-
-  @@unique([provider, providerAccountId])
-  @@map("accounts")
 }
 
 model MinecraftLinkRequest {

--- a/tests/admin-users.test.ts
+++ b/tests/admin-users.test.ts
@@ -31,9 +31,9 @@ describe('admin users API', () => {
     mockedPrisma.user.findMany.mockResolvedValue([
       {
         id: 'user-1',
-        name: 'Suki',
-        username: 'suki',
-        image: null,
+        discordDisplayName: 'Suki',
+        discordUsername: 'suki',
+        discordAvatarUrl: null,
         role: 'user',
         minecraftProfile: {
           uuid: 'minecraft-uuid',
@@ -94,7 +94,7 @@ describe('admin users API', () => {
     const where = mockedPrisma.user.findMany.mock.calls[0][0].where;
     expect(where.OR).toEqual(expect.arrayContaining([
       { id: { contains: '@suki', mode: 'insensitive' } },
-      { username: { contains: 'suki', mode: 'insensitive' } },
+      { discordUsername: { contains: 'suki', mode: 'insensitive' } },
     ]));
   });
 

--- a/tests/application-settings.test.ts
+++ b/tests/application-settings.test.ts
@@ -1,7 +1,7 @@
 import { prisma } from '@/lib/prisma';
 import {
-  applyApprovalPolicyToCreatedUser,
   getApplicationSettings,
+  getInitialUserRole,
   saveApplicationSettings,
 } from '@/lib/admin/application-settings-service';
 
@@ -11,9 +11,6 @@ jest.mock('@/lib/prisma', () => ({
       findUnique: jest.fn(),
       upsert: jest.fn(),
     },
-    user: {
-      update: jest.fn(),
-    },
   },
 }));
 
@@ -22,16 +19,6 @@ const mockedPrisma = prisma as unknown as {
     findUnique: jest.Mock;
     upsert: jest.Mock;
   };
-  user: { update: jest.Mock };
-};
-
-const pendingUser = {
-  id: 'user-1',
-  email: 'user@example.com',
-  emailVerified: null,
-  image: null,
-  name: 'Suki',
-  role: 'pending' as const,
 };
 
 describe('application settings service', () => {
@@ -62,29 +49,18 @@ describe('application settings service', () => {
     });
   });
 
-  it('keeps newly created users pending in manual mode', async () => {
+  it('returns the pending role in manual mode', async () => {
     mockedPrisma.applicationSettings.findUnique.mockResolvedValue({
       automaticUserApproval: false,
     });
 
-    await expect(applyApprovalPolicyToCreatedUser(pendingUser))
-      .resolves.toBe(pendingUser);
-    expect(mockedPrisma.user.update).not.toHaveBeenCalled();
+    await expect(getInitialUserRole()).resolves.toBe('pending');
   });
 
-  it('approves newly created users in automatic mode', async () => {
-    const approvedUser = { ...pendingUser, role: 'user' as const };
+  it('returns the user role in automatic mode', async () => {
     mockedPrisma.applicationSettings.findUnique.mockResolvedValue({
       automaticUserApproval: true,
     });
-    mockedPrisma.user.update.mockResolvedValue(approvedUser);
-
-    await expect(applyApprovalPolicyToCreatedUser(pendingUser))
-      .resolves.toEqual(approvedUser);
-    expect(mockedPrisma.user.update).toHaveBeenCalledWith({
-      where: { id: pendingUser.id },
-      data: { role: 'user' },
-      select: { role: true },
-    });
+    await expect(getInitialUserRole()).resolves.toBe('user');
   });
 });

--- a/tests/auth-callbacks.test.ts
+++ b/tests/auth-callbacks.test.ts
@@ -3,17 +3,21 @@ import { prisma } from '@/lib/prisma';
 
 jest.mock('@/lib/prisma', () => ({
   prisma: {
+    applicationSettings: {
+      findUnique: jest.fn(),
+    },
     user: {
       findUnique: jest.fn(),
-      update: jest.fn(),
+      upsert: jest.fn(),
     },
   },
 }));
 
 const mockedPrisma = prisma as unknown as {
+  applicationSettings: { findUnique: jest.Mock };
   user: {
     findUnique: jest.Mock;
-    update: jest.Mock;
+    upsert: jest.Mock;
   };
 };
 const jwtCallback = authCallbacks.jwt as (params: Record<string, unknown>) => Promise<any>;
@@ -42,15 +46,21 @@ describe('Auth.js callbacks', () => {
   });
 
   it('synchronizes Discord identity fields when a user signs in', async () => {
-    mockedPrisma.user.update.mockResolvedValue({ id: 'user-1' });
+    mockedPrisma.applicationSettings.findUnique.mockResolvedValue({
+      automaticUserApproval: false,
+    });
+    mockedPrisma.user.upsert.mockResolvedValue({
+      id: 'user-1',
+      discordUsername: 'new-name',
+      discordDisplayName: 'New Name',
+      discordAvatarUrl: 'https://cdn.discordapp.com/avatars/discord-1/avatar-hash.png',
+      role: 'admin',
+    });
 
     const token = await jwtCallback({
       token: {},
       user: {
         id: 'user-1',
-        role: 'admin',
-        username: 'old-name',
-        name: 'Old Name',
         image: null,
       },
       account: { provider: 'discord' },
@@ -62,12 +72,26 @@ describe('Auth.js callbacks', () => {
       },
     });
 
-    expect(mockedPrisma.user.update).toHaveBeenCalledWith({
-      where: { id: 'user-1' },
-      data: {
-        username: 'new-name',
-        name: 'New Name',
-        image: 'https://cdn.discordapp.com/avatars/discord-1/avatar-hash.png',
+    expect(mockedPrisma.user.upsert).toHaveBeenCalledWith({
+      where: { discordId: 'discord-1' },
+      create: {
+        discordId: 'discord-1',
+        discordUsername: 'new-name',
+        discordDisplayName: 'New Name',
+        discordAvatarUrl: 'https://cdn.discordapp.com/avatars/discord-1/avatar-hash.png',
+        role: 'pending',
+      },
+      update: {
+        discordUsername: 'new-name',
+        discordDisplayName: 'New Name',
+        discordAvatarUrl: 'https://cdn.discordapp.com/avatars/discord-1/avatar-hash.png',
+      },
+      select: {
+        id: true,
+        discordUsername: true,
+        discordDisplayName: true,
+        discordAvatarUrl: true,
+        role: true,
       },
     });
     expect(token).toMatchObject({

--- a/tests/content-management-query.test.ts
+++ b/tests/content-management-query.test.ts
@@ -85,10 +85,10 @@ describe('content management query', () => {
           { slug: searchText('@builder') },
         ] } } },
         { space: { is: { name: searchText('@builder') } } },
-        { primaryManager: { is: { name: searchText('@builder') } } },
-        { primaryManager: { is: { username: searchText('builder') } } },
+        { primaryManager: { is: { discordDisplayName: searchText('@builder') } } },
+        { primaryManager: { is: { discordUsername: searchText('builder') } } },
         { managers: { some: {
-          user: { is: { username: searchText('builder') } },
+          user: { is: { discordUsername: searchText('builder') } },
         } } },
       ],
     }]));
@@ -111,10 +111,10 @@ describe('content management query', () => {
         { name: searchText('redstone') },
         { slug: searchText('redstone') },
       ] } } },
-      { primaryManager: { is: { name: searchText('redstone') } } },
-      { primaryManager: { is: { username: searchText('redstone') } } },
+      { primaryManager: { is: { discordDisplayName: searchText('redstone') } } },
+      { primaryManager: { is: { discordUsername: searchText('redstone') } } },
       { managers: { some: {
-        user: { is: { username: searchText('redstone') } },
+        user: { is: { discordUsername: searchText('redstone') } },
       } } },
     ]);
   });

--- a/tests/map-entry-serialization.test.ts
+++ b/tests/map-entry-serialization.test.ts
@@ -47,9 +47,9 @@ function createEntry(primaryProfileUuid: string) {
     updatedAt: new Date('2026-07-29T12:00:00.000Z'),
     primaryManager: {
       id: 'primary-user',
-      image: null,
-      name: 'Primary',
-      username: 'primary',
+      discordAvatarUrl: null,
+      discordDisplayName: 'Primary',
+      discordUsername: 'primary',
       minecraftProfile: {
         uuid: primaryProfileUuid,
         name: 'PrimaryMC',

--- a/tests/map-entry-service.test.ts
+++ b/tests/map-entry-service.test.ts
@@ -127,13 +127,13 @@ describe('map-entry service', () => {
       {
         id: 'primary-user',
         role: 'user',
-        username: 'primary',
+        discordUsername: 'primary',
         minecraftProfile: { uuid: 'primary-uuid', name: 'PrimaryMC' },
       },
       {
         id: 'new-manager',
         role: 'user',
-        username: 'manager',
+        discordUsername: 'manager',
         minecraftProfile: { uuid: 'manager-uuid', name: 'ManagerMC' },
       },
     ]);
@@ -176,13 +176,13 @@ describe('map-entry service', () => {
       {
         id: 'next-primary',
         role: 'user',
-        username: 'next_primary',
+        discordUsername: 'next_primary',
         minecraftProfile: null,
       },
       {
         id: 'primary-user',
         role: 'user',
-        username: 'primary',
+        discordUsername: 'primary',
         minecraftProfile: null,
       },
     ]);
@@ -215,13 +215,13 @@ describe('map-entry service', () => {
       {
         id: 'primary-user',
         role: 'user',
-        username: 'primary',
+        discordUsername: 'primary',
         minecraftProfile: null,
       },
       {
         id: 'secondary-user',
         role: 'user',
-        username: 'secondary',
+        discordUsername: 'secondary',
         minecraftProfile: null,
       },
     ]);

--- a/tests/spaces-service.test.ts
+++ b/tests/spaces-service.test.ts
@@ -150,7 +150,7 @@ describe('space service', () => {
     tx.space.findUnique.mockResolvedValue(createSpaceAccess());
     tx.user.findUnique.mockResolvedValue({
       role: 'user',
-      username: 'next_manager',
+      discordUsername: 'next_manager',
     });
     tx.space.update.mockResolvedValue(createSpaceRecord({
       primaryManagerId: 'manager-user',
@@ -214,9 +214,9 @@ function createSpaceRecord(
 function createSpaceRecordBase() {
   const primaryManager = {
     id: 'primary-user',
-    name: 'Primary',
-    username: 'primary',
-    image: null,
+    discordDisplayName: 'Primary',
+    discordUsername: 'primary',
+    discordAvatarUrl: null,
     role: 'user',
     minecraftProfile: {
       uuid: 'member-b',
@@ -243,9 +243,9 @@ function createSpaceRecordBase() {
       userId: 'manager-user',
       user: {
         id: 'manager-user',
-        name: 'Manager',
-        username: 'next_manager',
-        image: null,
+        discordDisplayName: 'Manager',
+        discordUsername: 'next_manager',
+        discordAvatarUrl: null,
         role: 'user',
       },
     }],

--- a/types/discord-profile.d.ts
+++ b/types/discord-profile.d.ts
@@ -1,8 +1,6 @@
 export interface DiscordProfile {
-  id?: string;
-  username?: string;
+  id: string;
+  username: string;
   global_name?: string | null;
-  name?: string | null;
   avatar?: string | null;
-  image_url?: string;
 }

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -1,7 +1,5 @@
 import { DefaultSession } from "next-auth"
 import type { Role } from "@prisma/client"
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { AdapterUser } from "@auth/core/adapters"
 
 declare module "next-auth" {
   interface Session {
@@ -14,7 +12,7 @@ declare module "next-auth" {
   }
 
   interface User {
-    role: Role
+    role?: Role
     username?: string | null
     globalName?: string | null
   }
@@ -27,11 +25,5 @@ declare module "next-auth/jwt" {
     username?: string
     globalName?: string
     picture?: string
-  }
-}
-
-declare module "@auth/core/adapters" {
-  interface AdapterUser {
-    role: Role
   }
 }


### PR DESCRIPTION
## Authentication

- Restrict Discord OAuth to the `identify` scope and remove email collection.
- Replace the Prisma Auth.js adapter with JWT sessions and atomic Discord user synchronization.
- Preserve existing roles while refreshing Discord usernames, display names, and avatars.

## Database

- Replace generic OAuth account storage with explicit Discord identity fields.
- Remove persisted OAuth tokens, email fields, and the obsolete `accounts` table.
- Preserve internal user IDs and business relations while migrating Discord identities.

## Maintenance

- Centralize Discord identity serialization across APIs and content management.
- Update authentication tests and backend documentation.
- Remove the unused `@auth/prisma-adapter` dependency.
