### PR TITLE
DestinationCard's UI/UX closing behavior refactor

### DIFF
--- a/components/DestinationPanel.tsx
+++ b/components/DestinationPanel.tsx
@@ -1,7 +1,14 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useRef, useState, type FocusEvent } from 'react';
-import type React from 'react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type FocusEvent,
+  type MouseEvent,
+} from 'react';
 import DestinationPanelContent from '@/components/destination/DestinationPanelContent';
 import DestinationPanelHeader from '@/components/destination/DestinationPanelHeader';
 import type { DestinationCardActions } from '@/components/destination/destination-panel-types';
@@ -17,7 +24,13 @@ import {
   panelScrollFadeStyle,
 } from '@/lib/ui/panel';
 import type { ManualRouteCoordinates, PlayerRoutePosition, RouteData } from '@/lib/route-planning';
-import { toMapWorld, type DestinationType, type SelectDestinationHandler } from '@/lib/destination/selection';
+import {
+  resolveDestinationActivation,
+  toMapWorld,
+  type DestinationInputSource,
+  type DestinationType,
+  type SelectDestinationHandler,
+} from '@/lib/destination/selection';
 
 interface DestinationPanelProps {
   activeMapWorld?: MapWorld;
@@ -44,7 +57,7 @@ export default function DestinationPanel({
   playerPosition,
   manualCoords,
   onRouteChange,
-  onInfoClick
+  onInfoClick,
 }: DestinationPanelProps) {
   const [enabledTags, setEnabledTags] = useState<Set<string>>(new Set());
   const [searchQuery, setSearchQuery] = useState('');
@@ -111,20 +124,10 @@ export default function DestinationPanel({
   }, []);
 
 
-  const handleInfoClick = useCallback((event: React.MouseEvent, item: PlaceSummary | PortalSummary, type: DestinationType) => {
+  const handleInfoClick = useCallback((event: MouseEvent, item: PlaceSummary | PortalSummary, type: DestinationType) => {
     event.stopPropagation();
     onInfoClick(item, type);
   }, [onInfoClick]);
-
-  const handleCloseClick = useCallback((event: React.MouseEvent) => {
-      event.stopPropagation();
-      resetSearchHighlight();
-      onPlaceSelect(
-      '',
-      'place',
-      'overworld'
-    );
-  }, [resetSearchHighlight, onPlaceSelect]);
 
   const handlePanelBlur = (event: FocusEvent<HTMLDivElement>) => {
     const nextFocusedElement = event.relatedTarget;
@@ -139,6 +142,7 @@ export default function DestinationPanel({
   const selectedPortal = selectedType === 'portal' && selectedId
     ? portals.find((portal) => portal.id === selectedId)
     : undefined;
+  const selectedDestination = selectedPlace ?? selectedPortal;
   const hasSelectedDestination = Boolean(selectedPlace || selectedPortal);
   const highlightedDestination = filteredDestinations[highlightedDestinationIndex] ?? filteredDestinations[0] ?? null;
   const selectedMatchesHighlightedDestination = Boolean(
@@ -150,11 +154,17 @@ export default function DestinationPanel({
   const isPanelExpanded = isPanelHovered || hasPanelFocus || hasSelectedDestination;
   const contentHeight = `calc(100vh - 2rem - ${MAP_CONTROL_PANEL_COLLAPSED_HEIGHT_PX}px)`;
 
-    const handleDestinationClick = useCallback((
+  const handleCloseClick = useCallback((event: MouseEvent) => {
+    event.stopPropagation();
+    resetSearchHighlight();
+    onPlaceSelect('', selectedType, activeMapWorld);
+  }, [activeMapWorld, onPlaceSelect, resetSearchHighlight, selectedType]);
+
+  const handleDestinationClick = useCallback((
     id: string,
     type: DestinationType,
     world: string,
-    source: 'keyboard' | 'mouse' = 'mouse',
+    source: DestinationInputSource = 'mouse',
   ) => {
     if (source === 'mouse') {
       resetSearchHighlight();
@@ -162,20 +172,20 @@ export default function DestinationPanel({
       setIsSearchHighlightActive(true);
     }
 
-    if (!selectedId) {
-      const destinationWorld = toMapWorld(world);
-      onPlaceSelect(
-        selectedId === id && activeMapWorld === destinationWorld ? '' : id,
-        type,
-        destinationWorld
-      );
-    } else {
-      const item = selectedPlace || selectedPortal;
-      if(item)
-      onInfoClick(item, type)
+    const destinationWorld = toMapWorld(world);
+    const activation = resolveDestinationActivation(source, selectedId, id);
+
+    if (activation === 'open-info') {
+      if (selectedDestination) {
+        onInfoClick(selectedDestination, selectedType);
+      } else {
+        onPlaceSelect('', type, destinationWorld);
+      }
+      return;
     }
 
-  }, [selectedId, resetSearchHighlight, onPlaceSelect, activeMapWorld, selectedPlace, selectedPortal, onInfoClick]);
+    onPlaceSelect(activation === 'clear-selection' ? '' : id, type, destinationWorld);
+  }, [onInfoClick, onPlaceSelect, resetSearchHighlight, selectedDestination, selectedId, selectedType]);
 
   useEffect(() => {
     setHighlightedDestinationIndex(0);
@@ -212,7 +222,7 @@ export default function DestinationPanel({
     onDestinationClick: handleDestinationClick,
     onInfoClick: handleInfoClick,
     onCloseClick: handleCloseClick,
-  }), [handleDestinationClick, handleInfoClick, highlightedDestination, resetSearchHighlight, selectedId, shouldHighlightDestination, handleCloseClick]);
+  }), [handleCloseClick, handleDestinationClick, handleInfoClick, highlightedDestination, resetSearchHighlight, selectedId, shouldHighlightDestination]);
 
   return (
     <Panel

--- a/components/DestinationPanel.tsx
+++ b/components/DestinationPanel.tsx
@@ -44,7 +44,7 @@ export default function DestinationPanel({
   playerPosition,
   manualCoords,
   onRouteChange,
-  onInfoClick,
+  onInfoClick
 }: DestinationPanelProps) {
   const [enabledTags, setEnabledTags] = useState<Set<string>>(new Set());
   const [searchQuery, setSearchQuery] = useState('');
@@ -110,30 +110,21 @@ export default function DestinationPanel({
     setHighlightedDestinationIndex(0);
   }, []);
 
-  const handleDestinationClick = useCallback((
-    id: string,
-    type: DestinationType,
-    world: string,
-    source: 'keyboard' | 'mouse' = 'mouse'
-  ) => {
-    if (source === 'mouse') {
-      resetSearchHighlight();
-    } else {
-      setIsSearchHighlightActive(true);
-    }
-
-    const destinationWorld = toMapWorld(world);
-    onPlaceSelect(
-      selectedId === id && activeMapWorld === destinationWorld ? '' : id,
-      type,
-      destinationWorld
-    );
-  }, [activeMapWorld, onPlaceSelect, resetSearchHighlight, selectedId]);
 
   const handleInfoClick = useCallback((event: React.MouseEvent, item: PlaceSummary | PortalSummary, type: DestinationType) => {
     event.stopPropagation();
     onInfoClick(item, type);
   }, [onInfoClick]);
+
+  const handleCloseClick = useCallback((event: React.MouseEvent) => {
+      event.stopPropagation();
+      resetSearchHighlight();
+      onPlaceSelect(
+      '',
+      'place',
+      'overworld'
+    );
+  }, [resetSearchHighlight, onPlaceSelect]);
 
   const handlePanelBlur = (event: FocusEvent<HTMLDivElement>) => {
     const nextFocusedElement = event.relatedTarget;
@@ -158,6 +149,33 @@ export default function DestinationPanel({
   const shouldHighlightDestination = isSearchHighlightActive && hasSearchFocus && !hasSelectedDestination && !loading;
   const isPanelExpanded = isPanelHovered || hasPanelFocus || hasSelectedDestination;
   const contentHeight = `calc(100vh - 2rem - ${MAP_CONTROL_PANEL_COLLAPSED_HEIGHT_PX}px)`;
+
+    const handleDestinationClick = useCallback((
+    id: string,
+    type: DestinationType,
+    world: string,
+    source: 'keyboard' | 'mouse' = 'mouse',
+  ) => {
+    if (source === 'mouse') {
+      resetSearchHighlight();
+    } else {
+      setIsSearchHighlightActive(true);
+    }
+
+    if (!selectedId) {
+      const destinationWorld = toMapWorld(world);
+      onPlaceSelect(
+        selectedId === id && activeMapWorld === destinationWorld ? '' : id,
+        type,
+        destinationWorld
+      );
+    } else {
+      const item = selectedPlace || selectedPortal;
+      if(item)
+      onInfoClick(item, type)
+    }
+
+  }, [selectedId, resetSearchHighlight, onPlaceSelect, activeMapWorld, selectedPlace, selectedPortal, onInfoClick]);
 
   useEffect(() => {
     setHighlightedDestinationIndex(0);
@@ -193,7 +211,8 @@ export default function DestinationPanel({
     onMouseEnter: resetSearchHighlight,
     onDestinationClick: handleDestinationClick,
     onInfoClick: handleInfoClick,
-  }), [handleDestinationClick, handleInfoClick, highlightedDestination, resetSearchHighlight, selectedId, shouldHighlightDestination]);
+    onCloseClick: handleCloseClick,
+  }), [handleDestinationClick, handleInfoClick, highlightedDestination, resetSearchHighlight, selectedId, shouldHighlightDestination, handleCloseClick]);
 
   return (
     <Panel

--- a/components/destination/DestinationCards.tsx
+++ b/components/destination/DestinationCards.tsx
@@ -12,6 +12,7 @@ import {
   type MapIconCategory,
 } from '@/lib/place/categories';
 import type { DestinationCardActions } from './destination-panel-types';
+import CrossIcon from '../icons/CrossIcon';
 
 const DESCRIPTION_PREVIEW_MAX_LENGTH = 180;
 const DESCRIPTION_PREVIEW_MIN_SENTENCE_LENGTH = 40;
@@ -144,6 +145,18 @@ export function PlaceDestinationCard({ place, actions }: { place: PlaceSummary; 
         >
           <PlusIcon className={`w-4 h-4 ${themeColors.text.secondary}`} />
         </IconActionButton>
+        {
+          isSelected ? 
+          <IconActionButton
+          onClick={(event) => actions.onCloseClick(event)}
+          className="ml-2 mt-1 flex-shrink-0"
+          borderTone="secondary"
+          aria-label="Fermer"
+          >
+            <CrossIcon className={`w-4 h-4 ${themeColors.text.secondary}`} />
+        </IconActionButton>
+        : null
+        }
       </div>
       {isSelected && <DestinationDescription description={place.description} />}
       <DestinationCoordinates world={place.world} coordinates={place.coordinates} address={place.address} />
@@ -195,6 +208,18 @@ export function PortalDestinationCard({ portal, actions }: { portal: PortalSumma
         >
           <PlusIcon className={`w-4 h-4 ${themeColors.text.secondary}`} />
         </IconActionButton>
+        {
+          isSelected ? 
+          <IconActionButton
+          onClick={(event) => actions.onCloseClick(event)}
+          className="ml-2 mt-1 flex-shrink-0"
+          borderTone="secondary"
+          aria-label="Fermer"
+          >
+            <CrossIcon className={`w-4 h-4 ${themeColors.text.secondary}`} />
+        </IconActionButton>
+        : null
+        }
       </div>
       {isSelected && <DestinationDescription description={displayDescription} />}
       <DestinationCoordinates world={portal.world} coordinates={portal.coordinates} address={portal.address} />

--- a/components/destination/DestinationCards.tsx
+++ b/components/destination/DestinationCards.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import PlusIcon from '@/components/icons/PlusIcon';
+import CrossIcon from '@/components/icons/CrossIcon';
 import IconActionButton from '@/components/ui/IconActionButton';
 import WorldBadge from '@/components/ui/WorldBadge';
 import type { PlaceSummary, PortalSummary } from '@/lib/map-content/types';
@@ -12,7 +13,6 @@ import {
   type MapIconCategory,
 } from '@/lib/place/categories';
 import type { DestinationCardActions } from './destination-panel-types';
-import CrossIcon from '../icons/CrossIcon';
 
 const DESCRIPTION_PREVIEW_MAX_LENGTH = 180;
 const DESCRIPTION_PREVIEW_MIN_SENTENCE_LENGTH = 40;
@@ -115,6 +115,42 @@ function DestinationCoordinates({
   );
 }
 
+function DestinationCardButtons({
+  actions,
+  isSelected,
+  item,
+  type,
+}: {
+  actions: DestinationCardActions;
+  isSelected: boolean;
+  item: PlaceSummary | PortalSummary;
+  type: 'place' | 'portal';
+}) {
+  return (
+    <>
+      {isSelected ? (
+        <IconActionButton
+          onClick={actions.onCloseClick}
+          className="ml-2 mt-1 flex-shrink-0"
+          borderTone="secondary"
+          aria-label="Fermer"
+        >
+          <CrossIcon className={`w-4 h-4 ${themeColors.text.secondary}`} />
+        </IconActionButton>
+      ) : (
+        <IconActionButton
+          onClick={(event) => actions.onInfoClick(event, item, type)}
+          className="ml-2 mt-1 flex-shrink-0"
+          borderTone="secondary"
+          aria-label="Plus d'informations"
+        >
+          <PlusIcon className={`w-4 h-4 ${themeColors.text.secondary}`} />
+        </IconActionButton>
+      )}
+    </>
+  );
+}
+
 export function PlaceDestinationCard({ place, actions }: { place: PlaceSummary; actions: DestinationCardActions }) {
   const isSelected = actions.selectedId === place.id;
   const isHighlighted = actions.shouldHighlightDestination &&
@@ -137,26 +173,12 @@ export function PlaceDestinationCard({ place, actions }: { place: PlaceSummary; 
           <DestinationIcon category={category} />
           <DestinationName name={place.name} space={place.space} />
         </div>
-        <IconActionButton
-          onClick={(event) => actions.onInfoClick(event, place, 'place')}
-          className="ml-2 mt-1 flex-shrink-0"
-          borderTone="secondary"
-          aria-label="Plus d'informations"
-        >
-          <PlusIcon className={`w-4 h-4 ${themeColors.text.secondary}`} />
-        </IconActionButton>
-        {
-          isSelected ? 
-          <IconActionButton
-          onClick={(event) => actions.onCloseClick(event)}
-          className="ml-2 mt-1 flex-shrink-0"
-          borderTone="secondary"
-          aria-label="Fermer"
-          >
-            <CrossIcon className={`w-4 h-4 ${themeColors.text.secondary}`} />
-        </IconActionButton>
-        : null
-        }
+        <DestinationCardButtons
+          actions={actions}
+          isSelected={isSelected}
+          item={place}
+          type="place"
+        />
       </div>
       {isSelected && <DestinationDescription description={place.description} />}
       <DestinationCoordinates world={place.world} coordinates={place.coordinates} address={place.address} />
@@ -200,26 +222,12 @@ export function PortalDestinationCard({ portal, actions }: { portal: PortalSumma
           <DestinationIcon category="portail" />
           <DestinationName name={portal.name} space={portal.space} />
         </div>
-        <IconActionButton
-          onClick={(event) => actions.onInfoClick(event, portal, 'portal')}
-          className="ml-2 mt-1 flex-shrink-0"
-          borderTone="secondary"
-          aria-label="Plus d'informations"
-        >
-          <PlusIcon className={`w-4 h-4 ${themeColors.text.secondary}`} />
-        </IconActionButton>
-        {
-          isSelected ? 
-          <IconActionButton
-          onClick={(event) => actions.onCloseClick(event)}
-          className="ml-2 mt-1 flex-shrink-0"
-          borderTone="secondary"
-          aria-label="Fermer"
-          >
-            <CrossIcon className={`w-4 h-4 ${themeColors.text.secondary}`} />
-        </IconActionButton>
-        : null
-        }
+        <DestinationCardButtons
+          actions={actions}
+          isSelected={isSelected}
+          item={portal}
+          type="portal"
+        />
       </div>
       {isSelected && <DestinationDescription description={displayDescription} />}
       <DestinationCoordinates world={portal.world} coordinates={portal.coordinates} address={portal.address} />

--- a/components/destination/destination-panel-types.ts
+++ b/components/destination/destination-panel-types.ts
@@ -1,6 +1,9 @@
 import type React from 'react';
 import type { PlaceSummary, PortalSummary } from '@/lib/map-content/types';
-import type { DestinationType } from '@/lib/destination/selection';
+import type {
+  DestinationInputSource,
+  DestinationType,
+} from '@/lib/destination/selection';
 
 export type TagFilterLogic = 'SINGLE' | 'OR' | 'AND';
 
@@ -20,7 +23,7 @@ export type DestinationCardActions = {
     id: string,
     type: DestinationType,
     world: string,
-    source?: 'keyboard' | 'mouse'
+    source?: DestinationInputSource
   ) => void;
   onInfoClick: (
     event: React.MouseEvent,

--- a/components/destination/destination-panel-types.ts
+++ b/components/destination/destination-panel-types.ts
@@ -27,4 +27,5 @@ export type DestinationCardActions = {
     item: PlaceSummary | PortalSummary,
     type: DestinationType
   ) => void;
+  onCloseClick: (event: React.MouseEvent) => void;
 };

--- a/lib/destination/selection.ts
+++ b/lib/destination/selection.ts
@@ -1,6 +1,8 @@
 import { OVERWORLD_MAP_WORLD, type MapWorld } from '@/lib/map/metadata';
 
 export type DestinationType = 'place' | 'portal';
+export type DestinationInputSource = 'keyboard' | 'mouse';
+export type DestinationActivation = 'select' | 'open-info' | 'clear-selection';
 
 export type SelectDestinationHandler = (
   id: string,
@@ -11,3 +13,12 @@ export type SelectDestinationHandler = (
 export const toMapWorld = (world: string): MapWorld => (
   world === 'nether' ? 'nether' : OVERWORLD_MAP_WORLD
 );
+
+export function resolveDestinationActivation(
+  source: DestinationInputSource,
+  selectedId: string | undefined,
+  destinationId: string,
+): DestinationActivation {
+  if (selectedId !== destinationId) return 'select';
+  return source === 'mouse' ? 'open-info' : 'clear-selection';
+}

--- a/tests/destination-cards.test.ts
+++ b/tests/destination-cards.test.ts
@@ -1,0 +1,83 @@
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import {
+  PlaceDestinationCard,
+  PortalDestinationCard,
+} from '@/components/destination/DestinationCards';
+import type { DestinationCardActions } from '@/components/destination/destination-panel-types';
+import { resolveDestinationActivation } from '@/lib/destination/selection';
+import type { PlaceSummary, PortalSummary } from '@/lib/map-content/types';
+
+const place: PlaceSummary = {
+  id: 'place-1',
+  mapEntryId: 'entry-place-1',
+  name: 'Place test',
+  world: 'overworld',
+  coordinates: { x: 10, y: 64, z: 20 },
+  description: 'Description du lieu.',
+  address: null,
+  category: 'construction',
+  tags: [],
+  space: null,
+  previewImage: null,
+};
+
+const portal: PortalSummary = {
+  id: 'portal-1',
+  mapEntryId: 'entry-portal-1',
+  slug: 'portail-test',
+  name: 'Portail test',
+  world: 'overworld',
+  coordinates: { x: 30, y: 70, z: 40 },
+  description: 'Description du portail.',
+  address: '',
+  space: null,
+  'nether-associate': null,
+};
+
+function createActions(selectedId?: string): DestinationCardActions {
+  return {
+    selectedId,
+    highlightedDestination: null,
+    shouldHighlightDestination: false,
+    setCardRef: jest.fn(),
+    onMouseEnter: jest.fn(),
+    onDestinationClick: jest.fn(),
+    onInfoClick: jest.fn(),
+    onCloseClick: jest.fn(),
+  };
+}
+
+describe('destination card actions', () => {
+  it('shows the close action only for a selected place', () => {
+    const selectedMarkup = renderToStaticMarkup(createElement(
+      PlaceDestinationCard,
+      { place, actions: createActions(place.id) },
+    ));
+    const unselectedMarkup = renderToStaticMarkup(createElement(
+      PlaceDestinationCard,
+      { place, actions: createActions() },
+    ));
+
+    expect(selectedMarkup).toContain('aria-label="Fermer"');
+    expect(selectedMarkup).not.toContain('Plus d');
+    expect(unselectedMarkup).not.toContain('aria-label="Fermer"');
+    expect(unselectedMarkup).toContain('Plus d');
+  });
+
+  it('shows the close action for a selected portal', () => {
+    const markup = renderToStaticMarkup(createElement(
+      PortalDestinationCard,
+      { portal, actions: createActions(portal.id) },
+    ));
+
+    expect(markup).toContain('aria-label="Fermer"');
+    expect(markup).not.toContain('Plus d');
+  });
+
+  it('keeps mouse and keyboard activation behaviors distinct', () => {
+    expect(resolveDestinationActivation('mouse', place.id, place.id)).toBe('open-info');
+    expect(resolveDestinationActivation('keyboard', place.id, place.id)).toBe('clear-selection');
+    expect(resolveDestinationActivation('keyboard', undefined, place.id)).toBe('select');
+  });
+});


### PR DESCRIPTION
**Proposed changes:** Change `DestinationCard`'s UI+UX to add a close button and clicking the card now opens the More Info popup instead of closing. 

_**Suggestion for later:** Refactor `DestinationCard` to be only one component that can have variants instead of having a copy of the card for a normal place and for a nether portal._