### PR TITLE
Add Space Explorer's sorting controls

### DIFF
--- a/app/api/spaces/route.ts
+++ b/app/api/spaces/route.ts
@@ -9,6 +9,7 @@ import { createSpace, listSpaces } from '@/lib/spaces/service';
 import {
   listManageableSpaceReferences,
   loadSpaceSummaries,
+  parseSpaceSummarySort,
 } from '@/lib/spaces/summary-server';
 import { getSpaceActor, spaceErrorResponse } from './route-utils';
 
@@ -17,8 +18,11 @@ export async function GET(request: NextRequest) {
   if (view === 'summary') {
     const { page, pageSize } = getPagination(request.nextUrl.searchParams);
     const query = request.nextUrl.searchParams.get('q')?.trim() ?? '';
+    const sort = parseSpaceSummarySort(
+      request.nextUrl.searchParams.get('sort'),
+    );
     return NextResponse.json(
-      await loadSpaceSummaries(page, pageSize, query),
+      await loadSpaceSummaries(page, pageSize, query, sort),
     );
   }
   if (view === 'reference') {

--- a/components/DestinationPanel.tsx
+++ b/components/DestinationPanel.tsx
@@ -1,7 +1,14 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useRef, useState, type FocusEvent } from 'react';
-import type React from 'react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type FocusEvent,
+  type MouseEvent,
+} from 'react';
 import DestinationPanelContent from '@/components/destination/DestinationPanelContent';
 import DestinationPanelHeader from '@/components/destination/DestinationPanelHeader';
 import type { DestinationCardActions } from '@/components/destination/destination-panel-types';
@@ -17,7 +24,13 @@ import {
   panelScrollFadeStyle,
 } from '@/lib/ui/panel';
 import type { ManualRouteCoordinates, PlayerRoutePosition, RouteData } from '@/lib/route-planning';
-import { toMapWorld, type DestinationType, type SelectDestinationHandler } from '@/lib/destination/selection';
+import {
+  resolveDestinationActivation,
+  toMapWorld,
+  type DestinationInputSource,
+  type DestinationType,
+  type SelectDestinationHandler,
+} from '@/lib/destination/selection';
 
 interface DestinationPanelProps {
   activeMapWorld?: MapWorld;
@@ -44,7 +57,7 @@ export default function DestinationPanel({
   playerPosition,
   manualCoords,
   onRouteChange,
-  onInfoClick
+  onInfoClick,
 }: DestinationPanelProps) {
   const [enabledTags, setEnabledTags] = useState<Set<string>>(new Set());
   const [searchQuery, setSearchQuery] = useState('');
@@ -111,20 +124,10 @@ export default function DestinationPanel({
   }, []);
 
 
-  const handleInfoClick = useCallback((event: React.MouseEvent, item: PlaceSummary | PortalSummary, type: DestinationType) => {
+  const handleInfoClick = useCallback((event: MouseEvent, item: PlaceSummary | PortalSummary, type: DestinationType) => {
     event.stopPropagation();
     onInfoClick(item, type);
   }, [onInfoClick]);
-
-  const handleCloseClick = useCallback((event: React.MouseEvent) => {
-      event.stopPropagation();
-      resetSearchHighlight();
-      onPlaceSelect(
-      '',
-      'place',
-      'overworld'
-    );
-  }, [resetSearchHighlight, onPlaceSelect]);
 
   const handlePanelBlur = (event: FocusEvent<HTMLDivElement>) => {
     const nextFocusedElement = event.relatedTarget;
@@ -139,6 +142,7 @@ export default function DestinationPanel({
   const selectedPortal = selectedType === 'portal' && selectedId
     ? portals.find((portal) => portal.id === selectedId)
     : undefined;
+  const selectedDestination = selectedPlace ?? selectedPortal;
   const hasSelectedDestination = Boolean(selectedPlace || selectedPortal);
   const highlightedDestination = filteredDestinations[highlightedDestinationIndex] ?? filteredDestinations[0] ?? null;
   const selectedMatchesHighlightedDestination = Boolean(
@@ -150,11 +154,17 @@ export default function DestinationPanel({
   const isPanelExpanded = isPanelHovered || hasPanelFocus || hasSelectedDestination;
   const contentHeight = `calc(100vh - 2rem - ${MAP_CONTROL_PANEL_COLLAPSED_HEIGHT_PX}px)`;
 
-    const handleDestinationClick = useCallback((
+  const handleCloseClick = useCallback((event: MouseEvent) => {
+    event.stopPropagation();
+    resetSearchHighlight();
+    onPlaceSelect('', selectedType, activeMapWorld);
+  }, [activeMapWorld, onPlaceSelect, resetSearchHighlight, selectedType]);
+
+  const handleDestinationClick = useCallback((
     id: string,
     type: DestinationType,
     world: string,
-    source: 'keyboard' | 'mouse' = 'mouse',
+    source: DestinationInputSource = 'mouse',
   ) => {
     if (source === 'mouse') {
       resetSearchHighlight();
@@ -162,20 +172,20 @@ export default function DestinationPanel({
       setIsSearchHighlightActive(true);
     }
 
-    if (!selectedId) {
-      const destinationWorld = toMapWorld(world);
-      onPlaceSelect(
-        selectedId === id && activeMapWorld === destinationWorld ? '' : id,
-        type,
-        destinationWorld
-      );
-    } else {
-      const item = selectedPlace || selectedPortal;
-      if(item)
-      onInfoClick(item, type)
+    const destinationWorld = toMapWorld(world);
+    const activation = resolveDestinationActivation(source, selectedId, id);
+
+    if (activation === 'open-info') {
+      if (selectedDestination) {
+        onInfoClick(selectedDestination, selectedType);
+      } else {
+        onPlaceSelect('', type, destinationWorld);
+      }
+      return;
     }
 
-  }, [selectedId, resetSearchHighlight, onPlaceSelect, activeMapWorld, selectedPlace, selectedPortal, onInfoClick]);
+    onPlaceSelect(activation === 'clear-selection' ? '' : id, type, destinationWorld);
+  }, [onInfoClick, onPlaceSelect, resetSearchHighlight, selectedDestination, selectedId, selectedType]);
 
   useEffect(() => {
     setHighlightedDestinationIndex(0);
@@ -212,7 +222,7 @@ export default function DestinationPanel({
     onDestinationClick: handleDestinationClick,
     onInfoClick: handleInfoClick,
     onCloseClick: handleCloseClick,
-  }), [handleDestinationClick, handleInfoClick, highlightedDestination, resetSearchHighlight, selectedId, shouldHighlightDestination, handleCloseClick]);
+  }), [handleCloseClick, handleDestinationClick, handleInfoClick, highlightedDestination, resetSearchHighlight, selectedId, shouldHighlightDestination]);
 
   return (
     <Panel

--- a/components/DestinationPanel.tsx
+++ b/components/DestinationPanel.tsx
@@ -44,7 +44,7 @@ export default function DestinationPanel({
   playerPosition,
   manualCoords,
   onRouteChange,
-  onInfoClick,
+  onInfoClick
 }: DestinationPanelProps) {
   const [enabledTags, setEnabledTags] = useState<Set<string>>(new Set());
   const [searchQuery, setSearchQuery] = useState('');
@@ -110,30 +110,21 @@ export default function DestinationPanel({
     setHighlightedDestinationIndex(0);
   }, []);
 
-  const handleDestinationClick = useCallback((
-    id: string,
-    type: DestinationType,
-    world: string,
-    source: 'keyboard' | 'mouse' = 'mouse'
-  ) => {
-    if (source === 'mouse') {
-      resetSearchHighlight();
-    } else {
-      setIsSearchHighlightActive(true);
-    }
-
-    const destinationWorld = toMapWorld(world);
-    onPlaceSelect(
-      selectedId === id && activeMapWorld === destinationWorld ? '' : id,
-      type,
-      destinationWorld
-    );
-  }, [activeMapWorld, onPlaceSelect, resetSearchHighlight, selectedId]);
 
   const handleInfoClick = useCallback((event: React.MouseEvent, item: PlaceSummary | PortalSummary, type: DestinationType) => {
     event.stopPropagation();
     onInfoClick(item, type);
   }, [onInfoClick]);
+
+  const handleCloseClick = useCallback((event: React.MouseEvent) => {
+      event.stopPropagation();
+      resetSearchHighlight();
+      onPlaceSelect(
+      '',
+      'place',
+      'overworld'
+    );
+  }, [resetSearchHighlight, onPlaceSelect]);
 
   const handlePanelBlur = (event: FocusEvent<HTMLDivElement>) => {
     const nextFocusedElement = event.relatedTarget;
@@ -158,6 +149,33 @@ export default function DestinationPanel({
   const shouldHighlightDestination = isSearchHighlightActive && hasSearchFocus && !hasSelectedDestination && !loading;
   const isPanelExpanded = isPanelHovered || hasPanelFocus || hasSelectedDestination;
   const contentHeight = `calc(100vh - 2rem - ${MAP_CONTROL_PANEL_COLLAPSED_HEIGHT_PX}px)`;
+
+    const handleDestinationClick = useCallback((
+    id: string,
+    type: DestinationType,
+    world: string,
+    source: 'keyboard' | 'mouse' = 'mouse',
+  ) => {
+    if (source === 'mouse') {
+      resetSearchHighlight();
+    } else {
+      setIsSearchHighlightActive(true);
+    }
+
+    if (!selectedId) {
+      const destinationWorld = toMapWorld(world);
+      onPlaceSelect(
+        selectedId === id && activeMapWorld === destinationWorld ? '' : id,
+        type,
+        destinationWorld
+      );
+    } else {
+      const item = selectedPlace || selectedPortal;
+      if(item)
+      onInfoClick(item, type)
+    }
+
+  }, [selectedId, resetSearchHighlight, onPlaceSelect, activeMapWorld, selectedPlace, selectedPortal, onInfoClick]);
 
   useEffect(() => {
     setHighlightedDestinationIndex(0);
@@ -193,7 +211,8 @@ export default function DestinationPanel({
     onMouseEnter: resetSearchHighlight,
     onDestinationClick: handleDestinationClick,
     onInfoClick: handleInfoClick,
-  }), [handleDestinationClick, handleInfoClick, highlightedDestination, resetSearchHighlight, selectedId, shouldHighlightDestination]);
+    onCloseClick: handleCloseClick,
+  }), [handleDestinationClick, handleInfoClick, highlightedDestination, resetSearchHighlight, selectedId, shouldHighlightDestination, handleCloseClick]);
 
   return (
     <Panel

--- a/components/destination/DestinationCards.tsx
+++ b/components/destination/DestinationCards.tsx
@@ -12,6 +12,7 @@ import {
   type MapIconCategory,
 } from '@/lib/place/categories';
 import type { DestinationCardActions } from './destination-panel-types';
+import CrossIcon from '../icons/CrossIcon';
 
 const DESCRIPTION_PREVIEW_MAX_LENGTH = 180;
 const DESCRIPTION_PREVIEW_MIN_SENTENCE_LENGTH = 40;
@@ -144,6 +145,18 @@ export function PlaceDestinationCard({ place, actions }: { place: PlaceSummary; 
         >
           <PlusIcon className={`w-4 h-4 ${themeColors.text.secondary}`} />
         </IconActionButton>
+        {
+          isSelected ? 
+          <IconActionButton
+          onClick={(event) => actions.onCloseClick(event)}
+          className="ml-2 mt-1 flex-shrink-0"
+          borderTone="secondary"
+          aria-label="Fermer"
+          >
+            <CrossIcon className={`w-4 h-4 ${themeColors.text.secondary}`} />
+        </IconActionButton>
+        : null
+        }
       </div>
       {isSelected && <DestinationDescription description={place.description} />}
       <DestinationCoordinates world={place.world} coordinates={place.coordinates} address={place.address} />
@@ -195,6 +208,18 @@ export function PortalDestinationCard({ portal, actions }: { portal: PortalSumma
         >
           <PlusIcon className={`w-4 h-4 ${themeColors.text.secondary}`} />
         </IconActionButton>
+        {
+          isSelected ? 
+          <IconActionButton
+          onClick={(event) => actions.onCloseClick(event)}
+          className="ml-2 mt-1 flex-shrink-0"
+          borderTone="secondary"
+          aria-label="Fermer"
+          >
+            <CrossIcon className={`w-4 h-4 ${themeColors.text.secondary}`} />
+        </IconActionButton>
+        : null
+        }
       </div>
       {isSelected && <DestinationDescription description={displayDescription} />}
       <DestinationCoordinates world={portal.world} coordinates={portal.coordinates} address={portal.address} />

--- a/components/destination/DestinationCards.tsx
+++ b/components/destination/DestinationCards.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import PlusIcon from '@/components/icons/PlusIcon';
+import CrossIcon from '@/components/icons/CrossIcon';
 import IconActionButton from '@/components/ui/IconActionButton';
 import WorldBadge from '@/components/ui/WorldBadge';
 import type { PlaceSummary, PortalSummary } from '@/lib/map-content/types';
@@ -12,7 +13,6 @@ import {
   type MapIconCategory,
 } from '@/lib/place/categories';
 import type { DestinationCardActions } from './destination-panel-types';
-import CrossIcon from '../icons/CrossIcon';
 
 const DESCRIPTION_PREVIEW_MAX_LENGTH = 180;
 const DESCRIPTION_PREVIEW_MIN_SENTENCE_LENGTH = 40;
@@ -115,6 +115,42 @@ function DestinationCoordinates({
   );
 }
 
+function DestinationCardButtons({
+  actions,
+  isSelected,
+  item,
+  type,
+}: {
+  actions: DestinationCardActions;
+  isSelected: boolean;
+  item: PlaceSummary | PortalSummary;
+  type: 'place' | 'portal';
+}) {
+  return (
+    <>
+      {isSelected ? (
+        <IconActionButton
+          onClick={actions.onCloseClick}
+          className="ml-2 mt-1 flex-shrink-0"
+          borderTone="secondary"
+          aria-label="Fermer"
+        >
+          <CrossIcon className={`w-4 h-4 ${themeColors.text.secondary}`} />
+        </IconActionButton>
+      ) : (
+        <IconActionButton
+          onClick={(event) => actions.onInfoClick(event, item, type)}
+          className="ml-2 mt-1 flex-shrink-0"
+          borderTone="secondary"
+          aria-label="Plus d'informations"
+        >
+          <PlusIcon className={`w-4 h-4 ${themeColors.text.secondary}`} />
+        </IconActionButton>
+      )}
+    </>
+  );
+}
+
 export function PlaceDestinationCard({ place, actions }: { place: PlaceSummary; actions: DestinationCardActions }) {
   const isSelected = actions.selectedId === place.id;
   const isHighlighted = actions.shouldHighlightDestination &&
@@ -137,26 +173,12 @@ export function PlaceDestinationCard({ place, actions }: { place: PlaceSummary; 
           <DestinationIcon category={category} />
           <DestinationName name={place.name} space={place.space} />
         </div>
-        <IconActionButton
-          onClick={(event) => actions.onInfoClick(event, place, 'place')}
-          className="ml-2 mt-1 flex-shrink-0"
-          borderTone="secondary"
-          aria-label="Plus d'informations"
-        >
-          <PlusIcon className={`w-4 h-4 ${themeColors.text.secondary}`} />
-        </IconActionButton>
-        {
-          isSelected ? 
-          <IconActionButton
-          onClick={(event) => actions.onCloseClick(event)}
-          className="ml-2 mt-1 flex-shrink-0"
-          borderTone="secondary"
-          aria-label="Fermer"
-          >
-            <CrossIcon className={`w-4 h-4 ${themeColors.text.secondary}`} />
-        </IconActionButton>
-        : null
-        }
+        <DestinationCardButtons
+          actions={actions}
+          isSelected={isSelected}
+          item={place}
+          type="place"
+        />
       </div>
       {isSelected && <DestinationDescription description={place.description} />}
       <DestinationCoordinates world={place.world} coordinates={place.coordinates} address={place.address} />
@@ -200,26 +222,12 @@ export function PortalDestinationCard({ portal, actions }: { portal: PortalSumma
           <DestinationIcon category="portail" />
           <DestinationName name={portal.name} space={portal.space} />
         </div>
-        <IconActionButton
-          onClick={(event) => actions.onInfoClick(event, portal, 'portal')}
-          className="ml-2 mt-1 flex-shrink-0"
-          borderTone="secondary"
-          aria-label="Plus d'informations"
-        >
-          <PlusIcon className={`w-4 h-4 ${themeColors.text.secondary}`} />
-        </IconActionButton>
-        {
-          isSelected ? 
-          <IconActionButton
-          onClick={(event) => actions.onCloseClick(event)}
-          className="ml-2 mt-1 flex-shrink-0"
-          borderTone="secondary"
-          aria-label="Fermer"
-          >
-            <CrossIcon className={`w-4 h-4 ${themeColors.text.secondary}`} />
-        </IconActionButton>
-        : null
-        }
+        <DestinationCardButtons
+          actions={actions}
+          isSelected={isSelected}
+          item={portal}
+          type="portal"
+        />
       </div>
       {isSelected && <DestinationDescription description={displayDescription} />}
       <DestinationCoordinates world={portal.world} coordinates={portal.coordinates} address={portal.address} />

--- a/components/destination/destination-panel-types.ts
+++ b/components/destination/destination-panel-types.ts
@@ -1,6 +1,9 @@
 import type React from 'react';
 import type { PlaceSummary, PortalSummary } from '@/lib/map-content/types';
-import type { DestinationType } from '@/lib/destination/selection';
+import type {
+  DestinationInputSource,
+  DestinationType,
+} from '@/lib/destination/selection';
 
 export type TagFilterLogic = 'SINGLE' | 'OR' | 'AND';
 
@@ -20,7 +23,7 @@ export type DestinationCardActions = {
     id: string,
     type: DestinationType,
     world: string,
-    source?: 'keyboard' | 'mouse'
+    source?: DestinationInputSource
   ) => void;
   onInfoClick: (
     event: React.MouseEvent,

--- a/components/destination/destination-panel-types.ts
+++ b/components/destination/destination-panel-types.ts
@@ -27,4 +27,5 @@ export type DestinationCardActions = {
     item: PlaceSummary | PortalSummary,
     type: DestinationType
   ) => void;
+  onCloseClick: (event: React.MouseEvent) => void;
 };

--- a/components/spaces/SpaceExplorerOverlay.tsx
+++ b/components/spaces/SpaceExplorerOverlay.tsx
@@ -8,11 +8,12 @@ import MinecraftHeadImage from '@/components/ui/MinecraftHeadImage';
 import OverlayHeader from '@/components/ui/OverlayHeader';
 import OverlaySearchInput from '@/components/ui/OverlaySearchInput';
 import OverlaySurface from '@/components/ui/OverlaySurface';
+import PillTabs from '@/components/ui/PillTabs';
 import InfiniteLoadSentinel from '@/components/ui/InfiniteLoadSentinel';
 import { useDebouncedValue } from '@/components/ui/useDebouncedValue';
 import { spaceSummariesQueryOptions } from '@/lib/spaces/client';
 import { formatSpaceContentSummary } from '@/lib/spaces/summary';
-import type { SpaceSummary } from '@/lib/spaces/types';
+import type { SpaceSummary, SpaceSummarySort } from '@/lib/spaces/types';
 import { themeColors } from '@/lib/theme-colors';
 
 interface SpaceExplorerOverlayProps {
@@ -25,9 +26,10 @@ export default function SpaceExplorerOverlay({
   onOpenSpace,
 }: SpaceExplorerOverlayProps) {
   const [query, setQuery] = useState('');
+  const [sort, setSort] = useState<SpaceSummarySort>('name-asc');
   const deferredQuery = useDebouncedValue(query.trim());
   const spacesQuery = useInfiniteQuery(
-    spaceSummariesQueryOptions(deferredQuery),
+    spaceSummariesQueryOptions(deferredQuery, sort),
   );
   const spaces = useMemo(
     () => spacesQuery.data?.pages.flatMap(({ items }) => items) ?? [],
@@ -47,7 +49,13 @@ export default function SpaceExplorerOverlay({
 
       <div className={`relative min-h-0 flex-1 overflow-hidden ${themeColors.panel.primary} ${themeColors.transition}`}>
         <div className={`pointer-events-none absolute inset-x-0 top-0 z-10 h-20 gradient-top-solid-blur ${themeColors.transition}`} />
-        <div className="absolute inset-x-0 top-0 z-20 flex items-center px-6 pb-2 pt-4">
+        <div className="absolute inset-x-0 top-0 z-20 flex items-center gap-3 px-6 pb-2 pt-4">
+          <PillTabs
+            activeValue={sort}
+            ariaLabel="Trier les espaces"
+            onChange={setSort}
+            options={spaceSortOptions}
+          />
           <OverlaySearchInput
             ariaLabel="Rechercher un espace"
             onChange={setQuery}
@@ -74,6 +82,21 @@ export default function SpaceExplorerOverlay({
     </OverlaySurface>
   );
 }
+
+const spaceSortOptions = [
+  { value: 'name-asc', label: 'A ↑' },
+  { value: 'name-desc', label: 'Z ↓' },
+  {
+    value: 'content-desc',
+    label: 'Contenu ↑',
+    title: 'Espaces avec le plus de lieux et de portails en premier',
+  },
+  {
+    value: 'content-asc',
+    label: 'Contenu ↓',
+    title: 'Espaces avec le moins de lieux et de portails en premier',
+  },
+] as const;
 
 function SpaceExplorerContent({
   error,

--- a/components/ui/PillTabs.tsx
+++ b/components/ui/PillTabs.tsx
@@ -4,11 +4,13 @@ import { themeColors } from '@/lib/theme-colors';
 
 export interface PillTabOption<T extends string> {
   label: string;
+  title?: string;
   value: T;
 }
 
 interface PillTabsProps<T extends string> {
   activeValue: T;
+  ariaLabel?: string;
   className?: string;
   onChange: (value: T) => void;
   options: readonly PillTabOption<T>[];
@@ -16,12 +18,14 @@ interface PillTabsProps<T extends string> {
 
 export default function PillTabs<T extends string>({
   activeValue,
+  ariaLabel,
   className = '',
   onChange,
   options,
 }: PillTabsProps<T>) {
   return (
     <div
+      aria-label={ariaLabel}
       className={`flex items-center gap-2 ${className}`}
       role="tablist"
     >
@@ -36,6 +40,7 @@ export default function PillTabs<T extends string>({
             key={option.value}
             onClick={() => onChange(option.value)}
             role="tab"
+            title={option.title}
             type="button"
           >
             {option.label}

--- a/docs/BACKEND_API.md
+++ b/docs/BACKEND_API.md
@@ -17,7 +17,8 @@ Domain-specific endpoint documentation:
 Space responses include dynamically derived place and portal summaries and an
 aggregate trade-offer count for their associated map entries. These summaries
 expose ordered Minecraft owners without duplicating ownership, association, or
-offer-count data in the database.
+offer-count data in the database. The paginated explorer can order spaces by
+name or by their combined place and portal count.
 
 Services are autonomous managed content. They reuse map-entry management and
 Minecraft ownership without being associated with a place, world, coordinate,

--- a/docs/api/data-loading.md
+++ b/docs/api/data-loading.md
@@ -75,7 +75,10 @@ Parameters:
 `GET /api/spaces?view=summary` returns paginated explorer tiles. Each item
 contains the public space identity, preview image, first member, distinct member
 count, and place, portal, and offer counts. It accepts `page`, `pageSize`, and
-`q`; search covers the name, description, and Minecraft members.
+`q`; search covers the name, description, and Minecraft members. The optional
+`sort` parameter accepts `name-asc` (default), `name-desc`, `content-asc`, or
+`content-desc`. Content ordering uses the combined place and portal count, then
+the space name.
 
 `GET /api/spaces?view=reference` returns only the spaces manageable by the
 authenticated effective role. It is used by content forms and contains the

--- a/docs/api/spaces.md
+++ b/docs/api/spaces.md
@@ -151,6 +151,9 @@ The public application uses the lighter collection views documented in
 [Public Data Loading API](data-loading.md): `view=summary` for paginated space
 exploration and `view=reference` for authenticated form selectors. Omitting
 `view` keeps this complete collection contract available for compatibility.
+The summary view supports ascending or descending ordering by name or by the
+combined place and portal count. See the data-loading documentation for the
+accepted `sort` values.
 
 **Response:**
 

--- a/lib/destination/selection.ts
+++ b/lib/destination/selection.ts
@@ -1,6 +1,8 @@
 import { OVERWORLD_MAP_WORLD, type MapWorld } from '@/lib/map/metadata';
 
 export type DestinationType = 'place' | 'portal';
+export type DestinationInputSource = 'keyboard' | 'mouse';
+export type DestinationActivation = 'select' | 'open-info' | 'clear-selection';
 
 export type SelectDestinationHandler = (
   id: string,
@@ -11,3 +13,12 @@ export type SelectDestinationHandler = (
 export const toMapWorld = (world: string): MapWorld => (
   world === 'nether' ? 'nether' : OVERWORLD_MAP_WORLD
 );
+
+export function resolveDestinationActivation(
+  source: DestinationInputSource,
+  selectedId: string | undefined,
+  destinationId: string,
+): DestinationActivation {
+  if (selectedId !== destinationId) return 'select';
+  return source === 'mouse' ? 'open-info' : 'clear-selection';
+}

--- a/lib/query/keys.ts
+++ b/lib/query/keys.ts
@@ -9,6 +9,8 @@ export const queryKeys = {
     ['service-list', query, contact] as const
   ),
   spaceDetail: (slug: string) => ['space-detail', slug] as const,
-  spaceList: (query: string) => ['space-list', query] as const,
+  spaceList: (query: string, sort = 'name-asc') => (
+    ['space-list', query, sort] as const
+  ),
   spaceReferences: (role?: string) => ['space-references', role] as const,
 };

--- a/lib/spaces/client.ts
+++ b/lib/spaces/client.ts
@@ -11,6 +11,7 @@ import type {
   SpaceInput,
   SpaceReference,
   SpaceSummary,
+  SpaceSummarySort,
   SpaceUpdateInput,
 } from './types';
 
@@ -49,13 +50,16 @@ export function spaceReferencesQueryOptions(role?: string) {
   });
 }
 
-export function spaceSummariesQueryOptions(query: string) {
+export function spaceSummariesQueryOptions(
+  query: string,
+  sort: SpaceSummarySort,
+) {
   return infiniteQueryOptions({
-    queryKey: queryKeys.spaceList(query),
+    queryKey: queryKeys.spaceList(query, sort),
     initialPageParam: 1,
     placeholderData: keepPreviousData,
     queryFn: ({ pageParam, signal }) => requestJson<PaginatedResponse<SpaceSummary>>(
-      `/api/spaces?view=summary&page=${pageParam}&q=${encodeURIComponent(query)}`,
+      `/api/spaces?view=summary&page=${pageParam}&q=${encodeURIComponent(query)}&sort=${sort}`,
       { signal },
       'Impossible de charger les espaces.',
     ),

--- a/lib/spaces/summary-server.ts
+++ b/lib/spaces/summary-server.ts
@@ -4,7 +4,11 @@ import { prisma } from '@/lib/prisma';
 import type { PaginatedResponse } from '@/lib/api/pagination';
 import { toPaginationMeta } from '@/lib/api/pagination';
 import { contentCacheTags } from '@/lib/content/cache-tags';
-import type { SpaceReference, SpaceSummary } from './types';
+import type {
+  SpaceReference,
+  SpaceSummary,
+  SpaceSummarySort,
+} from './types';
 import { isAdministrationRole } from '@/lib/admin/roles';
 import { validTradeOfferWhere } from '@/lib/trade/query';
 
@@ -46,17 +50,19 @@ export async function listSpaceSummaries({
   page,
   pageSize,
   query,
+  sort,
 }: {
   page: number;
   pageSize: number;
   query: string;
+  sort: SpaceSummarySort;
 }): Promise<PaginatedResponse<SpaceSummary>> {
   const where = getSummaryWhere(query);
   const [records, total] = await prisma.$transaction([
     prisma.space.findMany({
       where,
       select: summarySelect,
-      orderBy: [{ name: 'asc' }, { id: 'asc' }],
+      orderBy: getSummaryOrderBy(sort),
       skip: (page - 1) * pageSize,
       take: pageSize,
     }),
@@ -70,12 +76,18 @@ export async function listSpaceSummaries({
 }
 
 const loadCachedSummaries = unstable_cache(
-  (page: number, pageSize: number, query: string) => listSpaceSummaries({
+  (
+    page: number,
+    pageSize: number,
+    query: string,
+    sort: SpaceSummarySort,
+  ) => listSpaceSummaries({
     page,
     pageSize,
     query,
+    sort,
   }),
-  ['space-summaries-v1'],
+  ['space-summaries-v2'],
   { revalidate: 300, tags: [contentCacheTags.spaces] },
 );
 
@@ -83,7 +95,19 @@ export const loadSpaceSummaries = (
   page: number,
   pageSize: number,
   query: string,
-) => loadCachedSummaries(page, pageSize, query);
+  sort: SpaceSummarySort,
+) => loadCachedSummaries(page, pageSize, query, sort);
+
+export function parseSpaceSummarySort(value: string | null): SpaceSummarySort {
+  if (
+    value === 'name-desc'
+    || value === 'content-asc'
+    || value === 'content-desc'
+  ) {
+    return value;
+  }
+  return 'name-asc';
+}
 
 export async function listManageableSpaceReferences(
   userId: string,
@@ -129,6 +153,20 @@ function getSummaryWhere(query: string): Prisma.SpaceWhereInput {
       },
     ],
   };
+}
+
+function getSummaryOrderBy(
+  sort: SpaceSummarySort,
+): Prisma.SpaceOrderByWithRelationInput[] {
+  const orderBy: Prisma.SpaceOrderByWithRelationInput[] = [];
+  if (sort === 'content-asc') {
+    orderBy.push({ entries: { _count: 'asc' } });
+  } else if (sort === 'content-desc') {
+    orderBy.push({ entries: { _count: 'desc' } });
+  }
+  const nameDirection = sort === 'name-desc' ? 'desc' : 'asc';
+  orderBy.push({ name: nameDirection }, { id: 'asc' });
+  return orderBy;
 }
 
 function toSpaceSummary(record: SummaryRecord): SpaceSummary {

--- a/lib/spaces/types.ts
+++ b/lib/spaces/types.ts
@@ -15,6 +15,11 @@ interface SpaceEditor
 }
 
 export type SpaceLogoBackground = 'color' | 'transparent';
+export type SpaceSummarySort =
+  | 'name-asc'
+  | 'name-desc'
+  | 'content-asc'
+  | 'content-desc';
 
 export interface SpaceReference {
   id: string;

--- a/tests/data-loading.test.ts
+++ b/tests/data-loading.test.ts
@@ -3,7 +3,10 @@ import { loadMapContentUncached } from '@/lib/map-content/server';
 import { listMarketOffers } from '@/lib/market/server';
 import { prisma } from '@/lib/prisma';
 import { listServices } from '@/lib/services/list-server';
-import { listSpaceSummaries } from '@/lib/spaces/summary-server';
+import {
+  listSpaceSummaries,
+  parseSpaceSummarySort,
+} from '@/lib/spaces/summary-server';
 
 jest.mock('@/lib/prisma', () => ({
   prisma: {
@@ -98,15 +101,33 @@ describe('data-loading projections', () => {
     spaceCount.mockResolvedValue(0);
 
     await listMarketOffers({ page: 2, pageSize: 12, query: 'diamant' });
-    await listSpaceSummaries({ page: 2, pageSize: 8, query: 'suki' });
+    await listSpaceSummaries({
+      page: 2,
+      pageSize: 8,
+      query: 'suki',
+      sort: 'content-desc',
+    });
 
     expect(offerFindMany).toHaveBeenCalledWith(expect.objectContaining({
       skip: 12,
       take: 12,
     }));
     expect(spaceFindMany).toHaveBeenCalledWith(expect.objectContaining({
+      orderBy: [
+        { entries: { _count: 'desc' } },
+        { name: 'asc' },
+        { id: 'asc' },
+      ],
       skip: 8,
       take: 8,
     }));
+  });
+
+  it('normalizes space explorer sort values', () => {
+    expect(parseSpaceSummarySort('name-desc')).toBe('name-desc');
+    expect(parseSpaceSummarySort('content-asc')).toBe('content-asc');
+    expect(parseSpaceSummarySort('content-desc')).toBe('content-desc');
+    expect(parseSpaceSummarySort('unsupported')).toBe('name-asc');
+    expect(parseSpaceSummarySort(null)).toBe('name-asc');
   });
 });

--- a/tests/destination-cards.test.ts
+++ b/tests/destination-cards.test.ts
@@ -1,0 +1,83 @@
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import {
+  PlaceDestinationCard,
+  PortalDestinationCard,
+} from '@/components/destination/DestinationCards';
+import type { DestinationCardActions } from '@/components/destination/destination-panel-types';
+import { resolveDestinationActivation } from '@/lib/destination/selection';
+import type { PlaceSummary, PortalSummary } from '@/lib/map-content/types';
+
+const place: PlaceSummary = {
+  id: 'place-1',
+  mapEntryId: 'entry-place-1',
+  name: 'Place test',
+  world: 'overworld',
+  coordinates: { x: 10, y: 64, z: 20 },
+  description: 'Description du lieu.',
+  address: null,
+  category: 'construction',
+  tags: [],
+  space: null,
+  previewImage: null,
+};
+
+const portal: PortalSummary = {
+  id: 'portal-1',
+  mapEntryId: 'entry-portal-1',
+  slug: 'portail-test',
+  name: 'Portail test',
+  world: 'overworld',
+  coordinates: { x: 30, y: 70, z: 40 },
+  description: 'Description du portail.',
+  address: '',
+  space: null,
+  'nether-associate': null,
+};
+
+function createActions(selectedId?: string): DestinationCardActions {
+  return {
+    selectedId,
+    highlightedDestination: null,
+    shouldHighlightDestination: false,
+    setCardRef: jest.fn(),
+    onMouseEnter: jest.fn(),
+    onDestinationClick: jest.fn(),
+    onInfoClick: jest.fn(),
+    onCloseClick: jest.fn(),
+  };
+}
+
+describe('destination card actions', () => {
+  it('shows the close action only for a selected place', () => {
+    const selectedMarkup = renderToStaticMarkup(createElement(
+      PlaceDestinationCard,
+      { place, actions: createActions(place.id) },
+    ));
+    const unselectedMarkup = renderToStaticMarkup(createElement(
+      PlaceDestinationCard,
+      { place, actions: createActions() },
+    ));
+
+    expect(selectedMarkup).toContain('aria-label="Fermer"');
+    expect(selectedMarkup).not.toContain('Plus d');
+    expect(unselectedMarkup).not.toContain('aria-label="Fermer"');
+    expect(unselectedMarkup).toContain('Plus d');
+  });
+
+  it('shows the close action for a selected portal', () => {
+    const markup = renderToStaticMarkup(createElement(
+      PortalDestinationCard,
+      { portal, actions: createActions(portal.id) },
+    ));
+
+    expect(markup).toContain('aria-label="Fermer"');
+    expect(markup).not.toContain('Plus d');
+  });
+
+  it('keeps mouse and keyboard activation behaviors distinct', () => {
+    expect(resolveDestinationActivation('mouse', place.id, place.id)).toBe('open-info');
+    expect(resolveDestinationActivation('keyboard', place.id, place.id)).toBe('clear-selection');
+    expect(resolveDestinationActivation('keyboard', undefined, place.id)).toBe('select');
+  });
+});


### PR DESCRIPTION
- Add `A ↑`, `Z ↓`, `Contenu ↑`, and `Contenu ↓` sorting controls beside the existing search field.
- Apply sorting on the server before pagination, using either names or the combined place and portal count.
- Scope query caching by search and sort values and document the new public API parameter.
